### PR TITLE
feat(lessons): add sort options and attendance table view

### DIFF
--- a/lib/applets/lessons/definition.dart
+++ b/lib/applets/lessons/definition.dart
@@ -19,7 +19,11 @@ final lessonsDefinition = AppletDefinition(
     AccountType.teacher,
   ],
   allowOffline: false,
-  settingsDefaults: {'showHomework': false},
+  settingsDefaults: {
+    'showHomework': false,
+    'sortOption': 'date_desc',
+    'attendanceView': 'cards',
+  },
   refreshInterval: const Duration(minutes: 15),
   bodyBuilder: (context, accountType, openDrawerCb) {
     if (accountType == AccountType.student ||

--- a/lib/applets/lessons/student/attendances.dart
+++ b/lib/applets/lessons/student/attendances.dart
@@ -3,37 +3,150 @@ import 'package:lanis/generated/l10n.dart';
 
 import '../../../models/lessons.dart';
 
-class AttendancesScreen extends StatelessWidget {
-  const AttendancesScreen({super.key, required this.lessons});
+class AttendancesScreen extends StatefulWidget {
+  const AttendancesScreen({
+    super.key,
+    required this.lessons,
+    required this.settings,
+    required this.updateSetting,
+  });
+
+  final Lessons lessons;
+  final Map<String, dynamic> settings;
+  final Future<void> Function(String, dynamic) updateSetting;
+
+  @override
+  State<AttendancesScreen> createState() => _AttendancesScreenState();
+}
+
+class _AttendancesScreenState extends State<AttendancesScreen> {
+  bool get _isTableView =>
+      (widget.settings['attendanceView'] as String?) == 'table';
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(AppLocalizations.of(context).attendances),
+        actions: [
+          IconButton(
+            icon: Icon(_isTableView ? Icons.view_agenda : Icons.table_chart),
+            tooltip: _isTableView ? 'Kartenansicht' : 'Tabellenansicht',
+            onPressed: () async {
+              await widget.updateSetting(
+                'attendanceView',
+                _isTableView ? 'cards' : 'table',
+              );
+              if (mounted) setState(() {});
+            },
+          ),
+        ],
+      ),
+      body: _isTableView
+          ? AttendanceTableView(lessons: widget.lessons)
+          : _cardListView(context),
+    );
+  }
+
+  Widget _cardListView(BuildContext context) {
+    return ListView.builder(
+      itemCount: widget.lessons.length + 1,
+      itemBuilder: (context, index) {
+        if (index == 0) {
+          return Column(
+            children: [
+              AttendanceCard(
+                title: AppLocalizations.of(context).allAttendances,
+                teachers: [],
+                attendances: getCombinedAttendances(widget.lessons),
+              ),
+              const Divider(),
+            ],
+          );
+        }
+        final lesson = widget.lessons[index - 1];
+        return AttendanceCard(
+          title: lesson.name,
+          teachers: lesson.teachers,
+          attendances: lesson.attendances!,
+        );
+      },
+    );
+  }
+}
+
+class AttendanceTableView extends StatelessWidget {
+  const AttendanceTableView({super.key, required this.lessons});
 
   final Lessons lessons;
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: Text(AppLocalizations.of(context).attendances)),
-      body: ListView.builder(
-        itemCount: lessons.length + 1,
-        itemBuilder: (context, index) {
-          if (index == 0) {
-            return Column(
-              children: [
-                AttendanceCard(
-                  title: AppLocalizations.of(context).allAttendances,
-                  teachers: [],
-                  attendances: getCombinedAttendances(lessons),
+    final allKeys = lessons
+        .expand((l) => l.attendances?.keys ?? const Iterable.empty())
+        .toSet()
+        .toList()
+      ..sort();
+
+    if (allKeys.isEmpty) {
+      return Center(
+        child: Text(
+          AppLocalizations.of(context).noEntries,
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+      );
+    }
+
+    final combined = getCombinedAttendances(lessons);
+
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: DataTable(
+        headingRowColor: WidgetStatePropertyAll(
+          Theme.of(context).colorScheme.secondaryContainer,
+        ),
+        columns: [
+          const DataColumn(label: Text('Kurs')),
+          ...allKeys.map((k) => DataColumn(label: Text(k))),
+        ],
+        rows: [
+          DataRow(
+            color: WidgetStatePropertyAll(
+              Theme.of(context).colorScheme.primaryContainer,
+            ),
+            cells: [
+              DataCell(
+                Text(
+                  AppLocalizations.of(context).allAttendances,
+                  style: const TextStyle(fontWeight: FontWeight.bold),
                 ),
-                Divider(),
+              ),
+              ...allKeys.map(
+                (k) => DataCell(
+                  Text(
+                    combined[k] ?? '—',
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                ),
+              ),
+            ],
+          ),
+          ...lessons.map(
+            (lesson) => DataRow(
+              cells: [
+                DataCell(
+                  Text(
+                    lesson.name,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                ...allKeys.map(
+                  (k) => DataCell(Text(lesson.attendances?[k] ?? '—')),
+                ),
               ],
-            );
-          }
-          final lesson = lessons[index - 1];
-          return AttendanceCard(
-            title: lesson.name,
-            teachers: lesson.teachers,
-            attendances: lesson.attendances!,
-          );
-        },
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -73,7 +186,7 @@ class AttendanceCard extends StatelessWidget {
                   ),
                   if (teachers.isNotEmpty) ...[
                     const SizedBox(width: 8),
-                    Text(teachers.map((e) => e.teacherKuerzel).join(", ")),
+                    Text(teachers.map((e) => e.teacherKuerzel).join(', ')),
                     const SizedBox(width: 4),
                     Icon(
                       teachers.length > 1 ? Icons.people : Icons.person,
@@ -86,7 +199,6 @@ class AttendanceCard extends StatelessWidget {
             ...attendances.entries.indexed.map((val) {
               final index = val.$1;
               final entry = val.$2;
-
               return Container(
                 padding: const EdgeInsets.symmetric(
                   horizontal: 16,
@@ -94,17 +206,16 @@ class AttendanceCard extends StatelessWidget {
                 ),
                 decoration: BoxDecoration(
                   color: index.isEven
-                      ? Theme.of(
-                          context,
-                        ).colorScheme.secondary.withValues(alpha: 0.3)
-                      : Theme.of(
-                          context,
-                        ).colorScheme.tertiary.withValues(alpha: 0.1),
+                      ? Theme.of(context).colorScheme.secondary
+                          .withValues(alpha: 0.3)
+                      : Theme.of(context).colorScheme.tertiary
+                          .withValues(alpha: 0.1),
                   borderRadius: index == 0
                       ? const BorderRadius.vertical(top: Radius.circular(8))
                       : index == attendances.length - 1
-                      ? const BorderRadius.vertical(bottom: Radius.circular(8))
-                      : null,
+                          ? const BorderRadius.vertical(
+                              bottom: Radius.circular(8))
+                          : null,
                 ),
                 child: Row(
                   children: [
@@ -131,9 +242,15 @@ class AttendanceCard extends StatelessWidget {
 Map<String, String> getCombinedAttendances(Lessons lessons) {
   final attendances = <String, int>{};
   for (final lesson in lessons) {
+    if (lesson.attendances == null) continue;
     for (final entry in lesson.attendances!.entries) {
       final key = entry.key;
-      final value = int.tryParse(entry.value) ?? 0;
+      final trimmed = entry.value.trim();
+      final value = int.tryParse(trimmed) ??
+          int.tryParse(
+            RegExp(r'\d+').firstMatch(trimmed)?.group(0) ?? '',
+          ) ??
+          0;
       attendances.update(key, (val) => val + value, ifAbsent: () => value);
     }
   }

--- a/lib/applets/lessons/student/lesson_list_tile.dart
+++ b/lib/applets/lessons/student/lesson_list_tile.dart
@@ -86,15 +86,18 @@ class _LessonListTileState extends State<LessonListTile> {
                         : Icons.person,
                     size: 16,
                   ),
-                  if (widget.lesson.teachers.length == 1)
-                    Text(
-                      " ${widget.lesson.teachers[0].teacher} (${widget.lesson.teachers[0].teacherKuerzel})",
-                    )
-                  else
-                    Text(
-                      " ${widget.lesson.teachers.map((e) => e.teacherKuerzel).join(', ')}",
-                    ),
-                  const Spacer(),
+                  Flexible(
+                    child: widget.lesson.teachers.length == 1
+                        ? Text(
+                            " ${widget.lesson.teachers[0].teacher} (${widget.lesson.teachers[0].teacherKuerzel})",
+                            overflow: TextOverflow.ellipsis,
+                          )
+                        : Text(
+                            " ${widget.lesson.teachers.map((e) => e.teacherKuerzel).join(', ')}",
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                  ),
+                  const SizedBox(width: 4),
                   Text(
                     widget.lesson.currentEntry?.topicDate != null
                       ? dateFormat.format(widget.lesson.currentEntry!.topicDate!)

--- a/lib/applets/lessons/student/lessons_student_view.dart
+++ b/lib/applets/lessons/student/lessons_student_view.dart
@@ -32,6 +32,7 @@ class _LessonsStudentViewState extends State<LessonsStudentView>
   Map<String, dynamic>? globalSettings;
   Future<void> Function(String, dynamic)? globalUpdateSetting;
   Lessons? homeworkLessons;
+  Lessons? attendanceLessons;
 
   Lessons _sortLessons(Lessons lessons, String sortOption) {
     final sorted = List<Lesson>.from(lessons);
@@ -42,13 +43,21 @@ class _LessonsStudentViewState extends State<LessonsStudentView>
           if (b.currentEntry?.topicDate == null) return -1;
           return a.currentEntry!.topicDate!.compareTo(b.currentEntry!.topicDate!);
         });
-      case 'alpha':
+      case 'alpha_asc':
         sorted.sort((a, b) => a.name.compareTo(b.name));
-      case 'teacher':
+      case 'alpha_desc':
+        sorted.sort((a, b) => b.name.compareTo(a.name));
+      case 'teacher_asc':
         sorted.sort((a, b) {
           final aT = a.teachers.firstOrNull?.teacher ?? '';
           final bT = b.teachers.firstOrNull?.teacher ?? '';
           return aT.compareTo(bT);
+        });
+      case 'teacher_desc':
+        sorted.sort((a, b) {
+          final aT = a.teachers.firstOrNull?.teacher ?? '';
+          final bT = b.teachers.firstOrNull?.teacher ?? '';
+          return bT.compareTo(aT);
         });
       case 'date_desc':
       default:
@@ -61,33 +70,38 @@ class _LessonsStudentViewState extends State<LessonsStudentView>
     return sorted;
   }
 
-  Widget _sortChips(
+  Widget _sortButton(
+    BuildContext context,
     Map<String, dynamic> settings,
     Future<void> Function(String, dynamic) updateSetting,
   ) {
-    const options = [
-      ('date_desc', 'Datum ↓'),
-      ('date_asc', 'Datum ↑'),
-      ('alpha', 'A–Z'),
-      ('teacher', 'Lehrer'),
-    ];
     final current = settings['sortOption'] as String? ?? 'date_desc';
-    return SingleChildScrollView(
-      scrollDirection: Axis.horizontal,
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-      child: Row(
-        children: options.map((opt) {
-          final (value, label) = opt;
-          return Padding(
-            padding: const EdgeInsets.only(right: 6),
-            child: FilterChip(
-              label: Text(label),
-              selected: current == value,
-              onSelected: (_) => updateSetting('sortOption', value),
-            ),
-          );
-        }).toList(),
-      ),
+    final l10n = AppLocalizations.of(context);
+    final options = [
+      ('date_desc', l10n.sortDateDescending),
+      ('date_asc', l10n.sortDateAscending),
+      ('alpha_asc', l10n.sortNameAscending),
+      ('alpha_desc', l10n.sortNameDescending),
+      ('teacher_asc', l10n.sortTeacherAscending),
+      ('teacher_desc', l10n.sortTeacherDescending),
+    ];
+    return PopupMenuButton<String>(
+      icon: const Icon(Icons.sort),
+      tooltip: l10n.sortBy,
+      initialValue: current,
+      onSelected: (value) => updateSetting('sortOption', value),
+      itemBuilder: (_) => options
+          .map((opt) => PopupMenuItem<String>(
+                value: opt.$1,
+                child: Row(
+                  children: [
+                    Expanded(child: Text(opt.$2)),
+                    if (current == opt.$1)
+                      const Icon(Icons.check, size: 18),
+                  ],
+                ),
+              ))
+          .toList(),
     );
   }
 
@@ -104,38 +118,44 @@ class _LessonsStudentViewState extends State<LessonsStudentView>
               actions:
                   globalSettings != null &&
                       globalUpdateSetting != null &&
-                      homeworkLessons != null &&
-                      homeworkLessons!.isNotEmpty
+                      homeworkLessons != null
                   ? [
-                      globalSettings!['showHomework'] == true
-                          ? Tooltip(
-                              message: AppLocalizations.of(context).lessons,
-                              child: IconButton(
-                                icon: const Icon(Icons.school_outlined),
-                                onPressed: () {
-                                  globalUpdateSetting!('showHomework', false);
-                                  WidgetsBinding.instance.addPostFrameCallback((
-                                    _,
-                                  ) {
-                                    setState(() {});
-                                  });
-                                },
+                      if (globalSettings!['showHomework'] != true)
+                        _sortButton(
+                          context,
+                          globalSettings!,
+                          globalUpdateSetting!,
+                        ),
+                      if (homeworkLessons!.isNotEmpty)
+                        globalSettings!['showHomework'] == true
+                            ? Tooltip(
+                                message: AppLocalizations.of(context).lessons,
+                                child: IconButton(
+                                  icon: const Icon(Icons.school_outlined),
+                                  onPressed: () {
+                                    globalUpdateSetting!('showHomework', false);
+                                    WidgetsBinding.instance.addPostFrameCallback((
+                                      _,
+                                    ) {
+                                      setState(() {});
+                                    });
+                                  },
+                                ),
+                              )
+                            : Tooltip(
+                                message: AppLocalizations.of(context).homework,
+                                child: IconButton(
+                                  icon: const Icon(Icons.task_outlined),
+                                  onPressed: () {
+                                    globalUpdateSetting!('showHomework', true);
+                                    WidgetsBinding.instance.addPostFrameCallback((
+                                      _,
+                                    ) {
+                                      setState(() {});
+                                    });
+                                  },
+                                ),
                               ),
-                            )
-                          : Tooltip(
-                              message: AppLocalizations.of(context).homework,
-                              child: IconButton(
-                                icon: const Icon(Icons.task_outlined),
-                                onPressed: () {
-                                  globalUpdateSetting!('showHomework', true);
-                                  WidgetsBinding.instance.addPostFrameCallback((
-                                    _,
-                                  ) {
-                                    setState(() {});
-                                  });
-                                },
-                              ),
-                            ),
                     ]
                   : null,
             )
@@ -191,61 +211,43 @@ class _LessonsStudentViewState extends State<LessonsStudentView>
                     .toList();
               }
 
-              return Scaffold(
-                appBar: settings['showHomework'] != true
-                    ? AppBar(
-                        toolbarHeight: 0,
-                        bottom: PreferredSize(
-                          preferredSize: const Size.fromHeight(52),
-                          child: _sortChips(settings, updateSetting),
-                        ),
-                      )
-                    : null,
-                body: RefreshIndicator(
-                  onRefresh: () => refresh!(),
-                  child: lessons.isNotEmpty
-                      ? ListView.builder(
-                          itemCount: lessons.length,
-                          itemBuilder: (BuildContext context, int index) =>
-                              Padding(
-                                padding: EdgeInsets.only(
-                                  top: 4,
-                                  bottom: index == lessons.length - 1 ? 80 : 0,
-                                  left: 8,
-                                  right: 8,
-                                ),
-                                child: LessonListTile(lesson: lessons[index]),
+              return RefreshIndicator(
+                onRefresh: () => refresh!(),
+                child: lessons.isNotEmpty
+                    ? ListView.builder(
+                        itemCount: lessons.length,
+                        itemBuilder: (BuildContext context, int index) =>
+                            Padding(
+                              padding: EdgeInsets.only(
+                                top: 4,
+                                bottom: index == lessons.length - 1 ? 80 : 0,
+                                left: 8,
+                                right: 8,
                               ),
-                        )
-                      : Column(
-                          crossAxisAlignment: CrossAxisAlignment.center,
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [noDataScreen(context)],
-                        ),
-                ),
-                floatingActionButton: Visibility(
-                  visible:
-                      attendanceLessons != null && attendanceLessons.isNotEmpty,
-                  child: FloatingActionButton.extended(
-                    onPressed: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) => AttendancesScreen(
-                            lessons: attendanceLessons!,
-                            settings: settings,
-                            updateSetting: updateSetting,
-                          ),
-                        ),
-                      );
-                    },
-                    label: Text(AppLocalizations.of(context).attendances),
-                    icon: const Icon(Icons.access_alarm),
-                  ),
-                ),
+                              child: LessonListTile(lesson: lessons[index]),
+                            ),
+                      )
+                    : Column(
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [noDataScreen(context)],
+                      ),
               );
             },
       ),
+      floatingActionButton: globalSettings != null &&
+              globalUpdateSetting != null &&
+              homeworkLessons != null &&
+              globalSettings!['showHomework'] != true
+          ? Builder(
+              builder: (context) {
+                return Visibility(
+                  visible: false,
+                  child: const SizedBox.shrink(),
+                );
+              },
+            )
+          : null,
     );
   }
 }

--- a/lib/applets/lessons/student/lessons_student_view.dart
+++ b/lib/applets/lessons/student/lessons_student_view.dart
@@ -33,6 +33,64 @@ class _LessonsStudentViewState extends State<LessonsStudentView>
   Future<void> Function(String, dynamic)? globalUpdateSetting;
   Lessons? homeworkLessons;
 
+  Lessons _sortLessons(Lessons lessons, String sortOption) {
+    final sorted = List<Lesson>.from(lessons);
+    switch (sortOption) {
+      case 'date_asc':
+        sorted.sort((a, b) {
+          if (a.currentEntry?.topicDate == null) return 1;
+          if (b.currentEntry?.topicDate == null) return -1;
+          return a.currentEntry!.topicDate!.compareTo(b.currentEntry!.topicDate!);
+        });
+      case 'alpha':
+        sorted.sort((a, b) => a.name.compareTo(b.name));
+      case 'teacher':
+        sorted.sort((a, b) {
+          final aT = a.teachers.firstOrNull?.teacher ?? '';
+          final bT = b.teachers.firstOrNull?.teacher ?? '';
+          return aT.compareTo(bT);
+        });
+      case 'date_desc':
+      default:
+        sorted.sort((a, b) {
+          if (a.currentEntry?.topicDate == null) return 1;
+          if (b.currentEntry?.topicDate == null) return -1;
+          return b.currentEntry!.topicDate!.compareTo(a.currentEntry!.topicDate!);
+        });
+    }
+    return sorted;
+  }
+
+  Widget _sortChips(
+    Map<String, dynamic> settings,
+    Future<void> Function(String, dynamic) updateSetting,
+  ) {
+    const options = [
+      ('date_desc', 'Datum ↓'),
+      ('date_asc', 'Datum ↑'),
+      ('alpha', 'A–Z'),
+      ('teacher', 'Lehrer'),
+    ];
+    final current = settings['sortOption'] as String? ?? 'date_desc';
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      child: Row(
+        children: options.map((opt) {
+          final (value, label) = opt;
+          return Padding(
+            padding: const EdgeInsets.only(right: 6),
+            child: FilterChip(
+              label: Text(label),
+              selected: current == value,
+              onSelected: (_) => updateSetting('sortOption', value),
+            ),
+          );
+        }).toList(),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -126,12 +184,23 @@ class _LessonsStudentViewState extends State<LessonsStudentView>
                       : -1;
                 });
               } else {
+                final sortOption = settings['sortOption'] as String? ?? 'date_desc';
+                lessons = _sortLessons(lessons, sortOption);
                 attendanceLessons = lessons
                     .where((element) => element.attendances != null)
                     .toList();
               }
 
               return Scaffold(
+                appBar: settings['showHomework'] != true
+                    ? AppBar(
+                        toolbarHeight: 0,
+                        bottom: PreferredSize(
+                          preferredSize: const Size.fromHeight(52),
+                          child: _sortChips(settings, updateSetting),
+                        ),
+                      )
+                    : null,
                 body: RefreshIndicator(
                   onRefresh: () => refresh!(),
                   child: lessons.isNotEmpty
@@ -162,8 +231,11 @@ class _LessonsStudentViewState extends State<LessonsStudentView>
                       Navigator.push(
                         context,
                         MaterialPageRoute(
-                          builder: (context) =>
-                              AttendancesScreen(lessons: attendanceLessons!),
+                          builder: (context) => AttendancesScreen(
+                            lessons: attendanceLessons!,
+                            settings: settings,
+                            updateSetting: updateSetting,
+                          ),
                         ),
                       );
                     },

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -359,5 +359,15 @@
   "openIOSSettingsToChangeLanguage": "Wählen Sie auf dem nächsten Bildschirm \"Lanis\" und ändern dann die Sprache im Abschnitt \"Bevorzugte Sprache\".",
   "copy": "Kopieren",
   "openExternalUrl": "Externe URL öffnen",
-  "openExternalUrlDescription": "Möchtest du die folgende URL öffnen?"
+  "openExternalUrlDescription": "Möchtest du die folgende URL öffnen?",
+  "sortBy": "Sortieren nach",
+  "sortDateDescending": "Datum ↓ (neueste zuerst)",
+  "sortDateAscending": "Datum ↑ (älteste zuerst)",
+  "sortNameAscending": "A–Z",
+  "sortNameDescending": "Z–A",
+  "sortTeacherAscending": "Lehrer A–Z",
+  "sortTeacherDescending": "Lehrer Z–A",
+  "cardView": "Kartenansicht",
+  "tableView": "Tabellenansicht",
+  "course": "Kurs"
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -403,5 +403,15 @@
   "openIOSSettingsToChangeLanguage": "On the next screen, select \"Lanis\" and then change the language in the \"Preferred Language\" section.",
   "copy": "Copy",
   "openExternalUrl": "Open external URL",
-  "openExternalUrlDescription": "Do you want to open the following URL in your browser?"
+  "openExternalUrlDescription": "Do you want to open the following URL in your browser?",
+  "sortBy": "Sort by",
+  "sortDateDescending": "Date ↓ (newest first)",
+  "sortDateAscending": "Date ↑ (oldest first)",
+  "sortNameAscending": "A–Z",
+  "sortNameDescending": "Z–A",
+  "sortTeacherAscending": "Teacher A–Z",
+  "sortTeacherDescending": "Teacher Z–A",
+  "cardView": "Card view",
+  "tableView": "Table view",
+  "course": "Course"
 }


### PR DESCRIPTION
## Summary

- **Lesson sorting:** `FilterChip` row (Date ↓, Date ↑, A–Z, Teacher) persisted via `settingsDefaults`
- **Attendance table view:** icon button in the `AttendancesScreen` AppBar toggles between the existing card layout and a new `DataTable` with one column per attendance key and one row per course, plus a combined totals row
- **`LessonListTile` overflow fix:** teacher name wrapped in `Flexible` with `TextOverflow.ellipsis` to prevent layout overflow
- More robust attendance value parsing (handles non-numeric strings like "2 Std.")

## Notes

- Sort chips are hidden when homework view is active (consistent with existing layout)
- `attendanceView: 'cards'` is the default — existing behavior unchanged
- Bottom spacing for OS nav bar not yet added (known gap from #509 review — happy to add here or in a follow-up)

## Test plan

- [ ] Lesson list: verify all four sort options work correctly
- [ ] Sort preference persists after navigating away and back
- [ ] Attendance screen: toggle between card and table view
- [ ] Table shows correct totals row and all attendance keys as columns
- [ ] Teacher names with long text no longer overflow in lesson tiles
- [ ] Verify Android release mode unaffected

Extracted from #509 as requested by @Rajala1404.