### PR TITLE
feat(ios): iOS Widgets, Live Activities & Deep Links

### DIFF
--- a/ios/LanisWidgets/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ios/LanisWidgets/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/LanisWidgets/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/LanisWidgets/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/LanisWidgets/Assets.xcassets/Contents.json
+++ b/ios/LanisWidgets/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/LanisWidgets/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/ios/LanisWidgets/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/LanisWidgets/Info.plist
+++ b/ios/LanisWidgets/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/ios/LanisWidgets/KalenderWidget.swift
+++ b/ios/LanisWidgets/KalenderWidget.swift
@@ -1,0 +1,404 @@
+import WidgetKit
+import SwiftUI
+
+struct CalendarTimelineEntry: TimelineEntry {
+    let date: Date
+    let data: CalendarData?
+}
+
+struct CalendarProvider: TimelineProvider {
+    func placeholder(in context: Context) -> CalendarTimelineEntry { CalendarTimelineEntry(date: Date(), data: nil) }
+    func getSnapshot(in context: Context, completion: @escaping (CalendarTimelineEntry) -> Void) {
+        completion(CalendarTimelineEntry(date: Date(), data: WidgetDataReader.calendar()))
+    }
+    func getTimeline(in context: Context, completion: @escaping (Timeline<CalendarTimelineEntry>) -> Void) {
+        let entry = CalendarTimelineEntry(date: Date(), data: WidgetDataReader.calendar())
+        let next = Calendar.current.date(byAdding: .hour, value: 1, to: Date())!
+        completion(Timeline(entries: [entry], policy: .after(next)))
+    }
+}
+
+// MARK: - Helpers
+
+private func dayLabel(_ date: Date?) -> String {
+    guard let date else { return "" }
+    let cal = Calendar.current
+    if cal.isDateInToday(date) { return "Heute" }
+    if cal.isDateInTomorrow(date) { return "Morgen" }
+    if #available(iOSApplicationExtension 15.0, *) {
+        return date.formatted(.dateTime.weekday(.abbreviated).day().month())
+    }
+    let f = DateFormatter()
+    f.locale = Locale(identifier: "de_DE")
+    f.dateFormat = "E d. MMM"
+    return f.string(from: date)
+}
+
+private func timeLabel(_ entry: CalendarEventEntry) -> String {
+    if entry.allDay { return "Ganztägig" }
+    guard let d = entry.startDate else { return "" }
+    if #available(iOSApplicationExtension 15.0, *) {
+        return d.formatted(.dateTime.hour().minute())
+    }
+    let f = DateFormatter()
+    f.dateFormat = "HH:mm"
+    return f.string(from: d)
+}
+
+// MARK: - Small: prominent day number + next event (Apple Calendar style)
+
+@available(iOSApplicationExtension 17.0, *)
+struct KalenderSmallView: View {
+    let data: CalendarData?
+    private var nextEvent: CalendarEventEntry? { data?.events.first }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Day number header — mirrors Apple Calendar widget
+            HStack(alignment: .firstTextBaseline, spacing: 4) {
+                Text(dayOfMonthString())
+                    .font(.system(size: 38, weight: .thin, design: .rounded))
+                    .foregroundStyle(.red)
+                Text(weekdayString())
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .padding(.bottom, 2)
+            }
+            Divider().padding(.vertical, 4)
+            if let e = nextEvent {
+                HStack(spacing: 6) {
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(e.accentColor)
+                        .frame(width: 3)
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(e.title)
+                            .font(.caption).bold()
+                            .lineLimit(2)
+                        Text(dayLabel(e.startDate))
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            } else {
+                Text("Keine\nEreignisse")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .containerBackground(.fill.tertiary, for: .widget)
+    }
+
+    private func dayOfMonthString() -> String {
+        let cal = Calendar.current
+        return "\(cal.component(.day, from: Date()))"
+    }
+
+    private func weekdayString() -> String {
+        let cal = Calendar.current
+        let idx = cal.component(.weekday, from: Date())
+        let symbols = cal.shortWeekdaySymbols
+        return symbols[idx - 1].uppercased()
+    }
+}
+
+// MARK: - Medium: date column left + event list right (Apple Calendar style)
+
+@available(iOSApplicationExtension 17.0, *)
+struct KalenderMediumView: View {
+    let data: CalendarData?
+    private var events: [CalendarEventEntry] { Array((data?.events ?? []).prefix(3)) }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            // Left column — date
+            VStack(alignment: .center, spacing: 2) {
+                Text(weekdayAbbr())
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .textCase(.uppercase)
+                Text(dayNumber())
+                    .font(.system(size: 32, weight: .thin, design: .rounded))
+                    .foregroundStyle(.red)
+            }
+            .frame(width: 44)
+
+            Divider()
+
+            // Right column — event list
+            VStack(alignment: .leading, spacing: 5) {
+                if events.isEmpty {
+                    Spacer()
+                    Text("Keine Ereignisse")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                } else {
+                    ForEach(events.indices, id: \.self) { i in
+                        let e = events[i]
+                        HStack(alignment: .center, spacing: 6) {
+                            Circle()
+                                .fill(e.accentColor)
+                                .frame(width: 8, height: 8)
+                            VStack(alignment: .leading, spacing: 0) {
+                                Text(e.title)
+                                    .font(.subheadline).bold()
+                                    .lineLimit(1)
+                                Text("\(dayLabel(e.startDate))  \(timeLabel(e))")
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                        }
+                    }
+                    Spacer(minLength: 0)
+                }
+            }
+        }
+        .padding(14)
+        .containerBackground(.fill.tertiary, for: .widget)
+    }
+
+    private func weekdayAbbr() -> String {
+        let cal = Calendar.current
+        let idx = cal.component(.weekday, from: Date())
+        return cal.shortWeekdaySymbols[idx - 1]
+    }
+
+    private func dayNumber() -> String {
+        "\(Calendar.current.component(.day, from: Date()))"
+    }
+}
+
+// MARK: - Large: mini month grid top + event list bottom
+
+@available(iOSApplicationExtension 17.0, *)
+struct KalenderLargeView: View {
+    let data: CalendarData?
+    private var events: [CalendarEventEntry] { Array((data?.events ?? []).prefix(5)) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            MiniMonthView(events: data?.events ?? [])
+            Divider()
+            if events.isEmpty {
+                Spacer()
+                Text("Keine bevorstehenden Ereignisse")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                Spacer()
+            } else {
+                ForEach(events.indices, id: \.self) { i in
+                    let e = events[i]
+                    HStack(spacing: 8) {
+                        RoundedRectangle(cornerRadius: 2)
+                            .fill(e.accentColor)
+                            .frame(width: 3, height: 30)
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(e.title).font(.subheadline).bold().lineLimit(1)
+                            Text("\(dayLabel(e.startDate))  \(timeLabel(e))")
+                                .font(.caption2).foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+        }
+        .padding(14)
+        .containerBackground(.fill.tertiary, for: .widget)
+    }
+}
+
+// MARK: - Mini month grid (used in Large)
+
+@available(iOSApplicationExtension 17.0, *)
+private struct MiniMonthView: View {
+    let events: [CalendarEventEntry]
+
+    private var cal: Calendar { Calendar.current }
+    private var today: Date { Date() }
+
+    private var monthDays: [(day: Int, date: Date, hasEvent: Bool)] {
+        let components = cal.dateComponents([.year, .month], from: today)
+        guard let firstOfMonth = cal.date(from: components),
+              let range = cal.range(of: .day, in: .month, for: firstOfMonth) else { return [] }
+
+        let eventDays: Set<Int> = Set(events.compactMap { e -> Int? in
+            guard let d = e.startDate, cal.isDate(d, equalTo: today, toGranularity: .month) else { return nil }
+            return cal.component(.day, from: d)
+        })
+
+        return range.compactMap { day -> (Int, Date, Bool)? in
+            var c = components; c.day = day
+            guard let date = cal.date(from: c) else { return nil }
+            return (day, date, eventDays.contains(day))
+        }
+    }
+
+    private var firstWeekday: Int {
+        let components = cal.dateComponents([.year, .month], from: today)
+        guard let firstOfMonth = cal.date(from: components) else { return 0 }
+        // weekday: 1=Sunday, 2=Monday, ..., 7=Saturday — shift so Monday=0
+        let weekday = cal.component(.weekday, from: firstOfMonth)
+        return (weekday + 5) % 7  // Sun(1)→6, Mon(2)→0, Tue(3)→1, ..., Sat(7)→5
+    }
+
+    private var monthName: String {
+        if #available(iOSApplicationExtension 15.0, *) {
+            return today.formatted(.dateTime.month(.wide))
+        }
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "de_DE")
+        f.dateFormat = "MMMM"
+        return f.string(from: today)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(monthName)
+                .font(.caption.bold())
+                .foregroundStyle(.primary)
+
+            // Weekday header — Mon first
+            let headers = ["Mo","Di","Mi","Do","Fr","Sa","So"]
+            HStack(spacing: 0) {
+                ForEach(headers, id: \.self) { h in
+                    Text(h)
+                        .font(.system(size: 9))
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity)
+                }
+            }
+
+            // Day grid
+            let todayDay = cal.component(.day, from: today)
+            let cells: [Int?] = Array(repeating: nil, count: firstWeekday) + monthDays.map { $0.day }
+            let rows = stride(from: 0, to: cells.count, by: 7).map { Array(cells[$0..<min($0+7, cells.count)]) }
+
+            ForEach(rows.indices, id: \.self) { r in
+                HStack(spacing: 0) {
+                    ForEach(0..<7, id: \.self) { col in
+                        let day = col < rows[r].count ? rows[r][col] : nil
+                        let hasEvent = day.flatMap { d in monthDays.first { $0.day == d } }?.hasEvent ?? false
+                        ZStack {
+                            if let d = day, d == todayDay {
+                                Circle().fill(Color.red).frame(width: 18, height: 18)
+                            }
+                            VStack(spacing: 1) {
+                                Text(day.map { "\($0)" } ?? "")
+                                    .font(.system(size: 10))
+                                    .foregroundStyle(day == todayDay ? .white : .primary)
+                                if hasEvent {
+                                    Circle().fill(day == todayDay ? Color.white : Color.accentColor).frame(width: 3, height: 3)
+                                } else {
+                                    Color.clear.frame(width: 3, height: 3)
+                                }
+                            }
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Widget
+
+@available(iOSApplicationExtension 17.0, *)
+struct KalenderWidget: Widget {
+    let kind = "KalenderWidget"
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: CalendarProvider()) { entry in
+            KalenderWidgetView(entry: entry)
+        }
+        .configurationDisplayName("Kalender")
+        .description("Zeigt bevorstehende Schulereignisse.")
+        .supportedFamilies({
+            var f: [WidgetFamily] = [.systemSmall, .systemMedium, .systemLarge]
+            if #available(iOSApplicationExtension 16.0, *) { f += [.accessoryCircular, .accessoryRectangular, .accessoryInline] }
+            return f
+        }())
+    }
+}
+
+@available(iOSApplicationExtension 17.0, *)
+struct KalenderWidgetView: View {
+    let entry: CalendarTimelineEntry
+    @Environment(\.widgetFamily) var family
+    var body: some View {
+        Group {
+            switch family {
+            case .systemSmall:  KalenderSmallView(data: entry.data)
+            case .systemMedium: KalenderMediumView(data: entry.data)
+            case .systemLarge:  KalenderLargeView(data: entry.data)
+            default:
+                if #available(iOSApplicationExtension 16.0, *) {
+                    let next = entry.data?.events.first
+                    switch family {
+                    case .accessoryCircular:
+                        ZStack {
+                            AccessoryWidgetBackground()
+                            if let d = next?.startDate {
+                                let days = Calendar.current.dateComponents([.day], from: Date(), to: d).day ?? 0
+                                Text(days == 0 ? "Heute" : "+\(days)").font(.caption2.bold()).widgetAccentable()
+                            } else {
+                                Image(systemName: "calendar").widgetAccentable()
+                            }
+                        }
+                    case .accessoryRectangular:
+                        VStack(alignment: .leading) {
+                            if let e = next {
+                                Text(e.title).font(.headline).widgetAccentable().lineLimit(1)
+                                Text(dayLabel(e.startDate)).font(.caption)
+                            } else {
+                                Text("Kein Ereignis").font(.caption)
+                            }
+                        }
+                    case .accessoryInline:
+                        if let e = next { Text("\(dayLabel(e.startDate)): \(e.title)") }
+                        else { Text("Keine Ereignisse") }
+                    default: EmptyView()
+                    }
+                }
+            }
+        }
+        .widgetURL(URL(string: "lanis://applet/kalender.php")!)
+    }
+}
+
+// MARK: - Previews
+
+#if DEBUG
+private let previewEvents: [CalendarEventEntry] = [
+    CalendarEventEntry(title: "Klassenfahrt Berlin", start: ISO8601DateFormatter().string(from: Calendar.current.date(byAdding: .day, value: 1, to: Date())!), allDay: true, color: "#E53935"),
+    CalendarEventEntry(title: "Elternsprechtag", start: ISO8601DateFormatter().string(from: Calendar.current.date(byAdding: .day, value: 2, to: Date())!), allDay: false, color: "#1E88E5"),
+    CalendarEventEntry(title: "Sportfest", start: ISO8601DateFormatter().string(from: Calendar.current.date(byAdding: .day, value: 3, to: Date())!), allDay: true, color: "#43A047"),
+    CalendarEventEntry(title: "Schulfeier 50 Jahre", start: ISO8601DateFormatter().string(from: Calendar.current.date(byAdding: .day, value: 5, to: Date())!), allDay: false, color: "#FB8C00"),
+    CalendarEventEntry(title: "Hausaufgaben Mathe", start: ISO8601DateFormatter().string(from: Calendar.current.date(byAdding: .day, value: 7, to: Date())!), allDay: true, color: "#8E24AA"),
+]
+
+@available(iOS 17.0, *)
+#Preview("Small", as: .systemSmall) {
+    KalenderWidget()
+} timeline: {
+    CalendarTimelineEntry(date: .now, data: CalendarData(updatedAt: "", events: previewEvents))
+}
+
+@available(iOS 17.0, *)
+#Preview("Medium", as: .systemMedium) {
+    KalenderWidget()
+} timeline: {
+    CalendarTimelineEntry(date: .now, data: CalendarData(updatedAt: "", events: previewEvents))
+}
+
+@available(iOS 17.0, *)
+#Preview("Large", as: .systemLarge) {
+    KalenderWidget()
+} timeline: {
+    CalendarTimelineEntry(date: .now, data: CalendarData(updatedAt: "", events: previewEvents))
+}
+#endif

--- a/ios/LanisWidgets/LanisWidgetsBundle.swift
+++ b/ios/LanisWidgets/LanisWidgetsBundle.swift
@@ -1,0 +1,16 @@
+import WidgetKit
+import SwiftUI
+
+@main
+@available(iOSApplicationExtension 16.0, *)
+struct LanisWidgetsBundle: WidgetBundle {
+    var body: some Widget {
+        StundenplanWidget()
+        VertretungsWidget()
+        KalenderWidget()
+        NachrichtenWidget()
+        if #available(iOSApplicationExtension 16.2, *) {
+            StundenLiveActivityWidget()
+        }
+    }
+}

--- a/ios/LanisWidgets/LiveActivityAttributes.swift
+++ b/ios/LanisWidgets/LiveActivityAttributes.swift
@@ -1,0 +1,44 @@
+import ActivityKit
+import Foundation
+
+// MARK: - Stunden Live Activity
+
+enum ActivityPhase: String, Codable {
+    case lesson
+    case `break`
+    case dayEnd
+}
+
+@available(iOS 16.2, *)
+struct LessonActivityAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+        var phase: ActivityPhase
+        var phaseStartTime: Date   // start of current phase (for progress bar)
+        var phaseEndTime: Date     // end of current phase (countdown target)
+        var nextLessonName: String?
+        var nextLessonRoom: String?
+        var nextLessonTeacher: String?
+        var nextLessonStart: String?  // "HH:mm" display string
+    }
+
+    var lessonName: String
+    var teacher: String?
+    var room: String?
+}
+
+// MARK: - Vertretungs Live Activity
+struct LiveSubstitutionEntry: Codable, Hashable {
+    let stunde: String
+    let fach: String?
+    let art: String?
+}
+
+@available(iOS 16.2, *)
+struct SubstitutionActivityAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+        var entries: [LiveSubstitutionEntry]
+        var count: Int
+    }
+
+    var date: String
+}

--- a/ios/LanisWidgets/NachrichtenWidget.swift
+++ b/ios/LanisWidgets/NachrichtenWidget.swift
@@ -1,0 +1,206 @@
+import WidgetKit
+import SwiftUI
+
+struct ConversationsTimelineEntry: TimelineEntry {
+    let date: Date
+    let data: ConversationsData?
+}
+
+struct ConversationsProvider: TimelineProvider {
+    func placeholder(in context: Context) -> ConversationsTimelineEntry { ConversationsTimelineEntry(date: Date(), data: nil) }
+    func getSnapshot(in context: Context, completion: @escaping (ConversationsTimelineEntry) -> Void) {
+        completion(ConversationsTimelineEntry(date: Date(), data: WidgetDataReader.conversations()))
+    }
+    func getTimeline(in context: Context, completion: @escaping (Timeline<ConversationsTimelineEntry>) -> Void) {
+        let entry = ConversationsTimelineEntry(date: Date(), data: WidgetDataReader.conversations())
+        let next = Calendar.current.date(byAdding: .minute, value: 30, to: Date())!
+        completion(Timeline(entries: [entry], policy: .after(next)))
+    }
+}
+
+@available(iOSApplicationExtension 17.0, *)
+struct NachrichtenSmallView: View {
+    let data: ConversationsData?
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Image("AppIcon").resizable().frame(width: 20, height: 20).clipShape(RoundedRectangle(cornerRadius: 4))
+                Text("Nachrichten").font(.caption2).foregroundStyle(.secondary)
+            }
+            Spacer()
+            let count = data?.unreadCount ?? 0
+            Text("\(count)").font(.system(size: 36, weight: .bold)).foregroundStyle(count > 0 ? Color.accentColor : Color.secondary)
+            Text("Ungelesen").font(.caption).foregroundStyle(.secondary)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+        .containerBackground(.fill.tertiary, for: .widget)
+    }
+}
+
+@available(iOSApplicationExtension 17.0, *)
+struct NachrichtenMediumView: View {
+    let data: ConversationsData?
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Image("AppIcon").resizable().frame(width: 16, height: 16).clipShape(RoundedRectangle(cornerRadius: 3))
+                Text("Nachrichten").font(.caption2).foregroundStyle(.secondary)
+                Spacer()
+                let count = data?.unreadCount ?? 0
+                if count > 0 {
+                    Text("\(count) ungelesen")
+                        .font(.caption2)
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 6).padding(.vertical, 2)
+                        .background(Color.accentColor)
+                        .clipShape(Capsule())
+                }
+            }
+            let msgs = Array((data?.latest ?? []).prefix(2))
+            if msgs.isEmpty {
+                Spacer()
+                Text("Keine Nachrichten").font(.subheadline).foregroundStyle(.secondary)
+                Spacer()
+            } else {
+                ForEach(msgs.indices, id: \.self) { i in
+                    let m = msgs[i]
+                    HStack(spacing: 6) {
+                        Circle().fill(m.isUnread ? Color.accentColor : Color.clear).frame(width: 6, height: 6)
+                        VStack(alignment: .leading, spacing: 0) {
+                            Text(m.sender).font(.caption.bold()).lineLimit(1)
+                            Text(m.subject).font(.caption).foregroundStyle(.secondary).lineLimit(1)
+                        }
+                        Spacer()
+                    }
+                }
+                Spacer()
+            }
+        }
+        .padding()
+        .containerBackground(.fill.tertiary, for: .widget)
+    }
+}
+
+@available(iOSApplicationExtension 17.0, *)
+struct NachrichtenLargeView: View {
+    let data: ConversationsData?
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Image("AppIcon").resizable().frame(width: 18, height: 18).clipShape(RoundedRectangle(cornerRadius: 4))
+                Text("Nachrichten").font(.caption).foregroundStyle(.secondary)
+                Spacer()
+                let count = data?.unreadCount ?? 0
+                if count > 0 {
+                    Text("\(count) ungelesen").font(.caption2).foregroundStyle(Color.accentColor)
+                }
+            }
+            Divider()
+            let msgs = data?.latest ?? []
+            if msgs.isEmpty {
+                Spacer()
+                Text("Keine Nachrichten").foregroundStyle(.secondary)
+                Spacer()
+            } else {
+                ForEach(msgs.indices, id: \.self) { i in
+                    let m = msgs[i]
+                    HStack(spacing: 8) {
+                        Circle().fill(m.isUnread ? Color.accentColor : Color.secondary.opacity(0.3)).frame(width: 8, height: 8)
+                        VStack(alignment: .leading, spacing: 0) {
+                            Text(m.sender).font(.subheadline).bold().lineLimit(1)
+                            Text(m.subject).font(.caption).foregroundStyle(.secondary).lineLimit(1)
+                        }
+                        Spacer()
+                    }
+                }
+            }
+            Spacer()
+        }
+        .padding()
+        .containerBackground(.fill.tertiary, for: .widget)
+    }
+}
+
+@available(iOSApplicationExtension 17.0, *)
+struct NachrichtenWidget: Widget {
+    let kind = "NachrichtenWidget"
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: ConversationsProvider()) { entry in
+            NachrichtenWidgetView(entry: entry)
+        }
+        .configurationDisplayName("Nachrichten")
+        .description("Zeigt ungelesene Nachrichten.")
+        .supportedFamilies({
+            var f: [WidgetFamily] = [.systemSmall, .systemMedium]
+            if #available(iOSApplicationExtension 16.0, *) { f += [.accessoryCircular, .accessoryRectangular, .accessoryInline] }
+            return f
+        }())
+    }
+}
+
+@available(iOSApplicationExtension 17.0, *)
+struct NachrichtenWidgetView: View {
+    let entry: ConversationsTimelineEntry
+    @Environment(\.widgetFamily) var family
+    var body: some View {
+        Group {
+            switch family {
+            case .systemSmall: NachrichtenSmallView(data: entry.data)
+            case .systemMedium: NachrichtenMediumView(data: entry.data)
+            default:
+                if #available(iOSApplicationExtension 16.0, *) {
+                    let count = entry.data?.unreadCount ?? 0
+                    switch family {
+                    case .accessoryCircular:
+                        ZStack {
+                            AccessoryWidgetBackground()
+                            Text("\(count)").font(.headline.bold()).widgetAccentable()
+                        }
+                    case .accessoryRectangular:
+                        VStack(alignment: .leading) {
+                            if let first = entry.data?.latest.first {
+                                Text(first.sender).font(.headline).widgetAccentable().lineLimit(1)
+                                Text(first.subject).font(.caption).lineLimit(1)
+                            } else {
+                                Text("Keine Nachrichten").font(.caption)
+                            }
+                        }
+                    case .accessoryInline:
+                        Text(count > 0 ? "\(count) ungelesene Nachricht\(count == 1 ? "" : "en")" : "Keine neuen Nachrichten")
+                    default: EmptyView()
+                    }
+                }
+            }
+        }
+        .widgetURL(URL(string: "lanis://applet/nachrichten.php")!)
+    }
+}
+
+// MARK: - Previews
+
+#if DEBUG
+private let previewConvData = ConversationsData(
+    updatedAt: "",
+    unreadCount: 2,
+    latest: [
+        ConversationEntry(sender: "Herr Brandt", subject: "Klassenfahrt: Wichtige Infos", isUnread: true),
+        ConversationEntry(sender: "Schulleitung", subject: "Informationen zum Schuljahresabschluss", isUnread: false),
+        ConversationEntry(sender: "Frau Koch", subject: "Hausaufgaben Deutsch", isUnread: false),
+    ]
+)
+
+@available(iOS 17.0, *)
+#Preview("Small", as: .systemSmall) {
+    NachrichtenWidget()
+} timeline: {
+    ConversationsTimelineEntry(date: .now, data: previewConvData)
+}
+
+@available(iOS 17.0, *)
+#Preview("Medium", as: .systemMedium) {
+    NachrichtenWidget()
+} timeline: {
+    ConversationsTimelineEntry(date: .now, data: previewConvData)
+}
+#endif

--- a/ios/LanisWidgets/SharedModels.swift
+++ b/ios/LanisWidgets/SharedModels.swift
@@ -1,0 +1,93 @@
+import Foundation
+import SwiftUI
+
+let appGroupID = "group.io.github.alessioc42.sph.widgets"
+
+struct TimetableEntry: Decodable {
+    let name: String
+    let room: String?
+    let teacher: String?
+    let start: String
+    let end: String
+    let stunde: Int
+    let color: String?
+
+    var accentColor: Color {
+        guard let hex = color else { return .accentColor }
+        return Color(hex: hex) ?? .accentColor
+    }
+}
+
+struct TimetableData: Decodable {
+    let updatedAt: String
+    let today: [TimetableEntry]
+    let currentLesson: TimetableEntry?
+}
+
+struct SubstitutionEntry: Decodable {
+    let stunde: String
+    let fach: String?
+    let art: String?
+    let raum: String?
+    let vertreter: String?
+}
+
+struct SubstitutionData: Decodable {
+    let updatedAt: String
+    let date: String
+    let entries: [SubstitutionEntry]
+}
+
+struct CalendarEventEntry: Decodable {
+    let title: String
+    let start: String
+    let allDay: Bool
+    let color: String?
+
+    private static let iso8601 = ISO8601DateFormatter()
+
+    var startDate: Date? {
+        CalendarEventEntry.iso8601.date(from: start)
+    }
+
+    var accentColor: Color {
+        guard let hex = color else { return .accentColor }
+        return Color(hex: hex) ?? .accentColor
+    }
+}
+
+struct CalendarData: Decodable {
+    let updatedAt: String
+    let events: [CalendarEventEntry]
+}
+
+struct ConversationEntry: Decodable {
+    let sender: String
+    let subject: String
+    let isUnread: Bool
+}
+
+struct ConversationsData: Decodable {
+    let updatedAt: String
+    let unreadCount: Int
+    let latest: [ConversationEntry]
+}
+
+// MARK: - Color from Hex helper
+extension Color {
+    init?(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+        let r, g, b: Double
+        switch hex.count {
+        case 6:
+            r = Double((int >> 16) & 0xFF) / 255
+            g = Double((int >> 8) & 0xFF) / 255
+            b = Double(int & 0xFF) / 255
+        default:
+            return nil
+        }
+        self.init(red: r, green: g, blue: b)
+    }
+}

--- a/ios/LanisWidgets/StundenLiveActivity.swift
+++ b/ios/LanisWidgets/StundenLiveActivity.swift
@@ -1,0 +1,286 @@
+import ActivityKit
+import WidgetKit
+import SwiftUI
+
+@available(iOSApplicationExtension 16.2, *)
+struct StundenLiveActivityView: View {
+    let attributes: LessonActivityAttributes
+    let state: LessonActivityAttributes.ContentState
+
+    var body: some View {
+        switch state.phase {
+        case .lesson:
+            lessonView
+        case .break:
+            breakView
+        case .dayEnd:
+            dayEndView
+        }
+    }
+
+    // MARK: Lesson view (current behaviour)
+    private var lessonView: some View {
+        VStack(spacing: 8) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 6) {
+                        Image("AppIcon").resizable().frame(width: 16, height: 16).clipShape(RoundedRectangle(cornerRadius: 3))
+                        Text(attributes.lessonName).font(.headline).bold()
+                    }
+                    HStack(spacing: 8) {
+                        if let room = attributes.room {
+                            Label(room, systemImage: "mappin").font(.caption).foregroundStyle(.secondary)
+                        }
+                        if let teacher = attributes.teacher {
+                            Label(teacher, systemImage: "person").font(.caption).foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                Spacer()
+                Text(timerInterval: Date()...state.phaseEndTime, countsDown: true)
+                    .font(.title2.monospacedDigit().bold())
+                    .foregroundColor(.accentColor)
+                    .frame(width: 70, alignment: .trailing)
+            }
+
+            progressBar
+
+            if let next = state.nextLessonName {
+                HStack {
+                    Text("Danach: \(next)\(state.nextLessonStart.map { " um \($0)" } ?? "")").font(.caption).foregroundStyle(.secondary)
+                    Spacer()
+                }
+            }
+        }
+        .padding()
+    }
+
+    // MARK: Break view
+    private var breakView: some View {
+        VStack(spacing: 8) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 4) {
+                        Text(timerInterval: Date()...state.phaseEndTime, countsDown: true)
+                            .font(.title2.monospacedDigit().bold())
+                            .foregroundColor(.accentColor)
+                        if let name = state.nextLessonName {
+                            Text("· \(name)").font(.headline).bold()
+                        }
+                    }
+                    HStack(spacing: 8) {
+                        if let room = state.nextLessonRoom {
+                            Label(room, systemImage: "mappin").font(.caption).foregroundStyle(.secondary)
+                        }
+                        if let teacher = state.nextLessonTeacher {
+                            Label(teacher, systemImage: "person").font(.caption).foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                Spacer()
+            }
+
+            progressBar
+        }
+        .padding()
+    }
+
+    // MARK: Day end view
+    private var dayEndView: some View {
+        HStack(spacing: 10) {
+            Image("AppIcon").resizable().frame(width: 28, height: 28).clipShape(RoundedRectangle(cornerRadius: 6))
+            Text("Schultag beendet").font(.headline).bold()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+
+    // MARK: Progress bar (shared)
+    private var progressBar: some View {
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                RoundedRectangle(cornerRadius: 3).fill(Color.secondary.opacity(0.2)).frame(height: 4)
+                RoundedRectangle(cornerRadius: 3).fill(Color.accentColor).frame(width: geo.size.width * progressFraction, height: 4)
+            }
+        }.frame(height: 4)
+    }
+
+    private var progressFraction: CGFloat {
+        let total = state.phaseEndTime.timeIntervalSince(state.phaseStartTime)
+        guard total > 0 else { return 0 }
+        let elapsed = Date().timeIntervalSince(state.phaseStartTime)
+        return min(max(CGFloat(elapsed / total), 0), 1)
+    }
+}
+
+@available(iOSApplicationExtension 16.2, *)
+struct StundenLiveActivityWidget: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: LessonActivityAttributes.self) { context in
+            StundenLiveActivityView(attributes: context.attributes, state: context.state)
+                .activityBackgroundTint(Color.clear)
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    HStack {
+                        Image("AppIcon").resizable().frame(width: 20, height: 20).clipShape(RoundedRectangle(cornerRadius: 4))
+                        switch context.state.phase {
+                        case .lesson:
+                            Text(context.attributes.lessonName).font(.headline)
+                        case .break:
+                            Text(context.state.nextLessonName ?? "Pause").font(.headline)
+                        case .dayEnd:
+                            Text("Schultag beendet").font(.headline)
+                        }
+                    }
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    switch context.state.phase {
+                    case .lesson, .break:
+                        Text(timerInterval: Date()...context.state.phaseEndTime, countsDown: true)
+                            .font(.headline.monospacedDigit())
+                            .foregroundColor(.accentColor)
+                    case .dayEnd:
+                        EmptyView()
+                    }
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    HStack {
+                        switch context.state.phase {
+                        case .lesson:
+                            if let room = context.attributes.room {
+                                Label(room, systemImage: "mappin").font(.caption)
+                            }
+                            if let teacher = context.attributes.teacher {
+                                Label(teacher, systemImage: "person").font(.caption)
+                            }
+                            Spacer()
+                            if let next = context.state.nextLessonName {
+                                Text("→ \(next)").font(.caption).foregroundStyle(.secondary)
+                            }
+                        case .break:
+                            if let room = context.state.nextLessonRoom {
+                                Label(room, systemImage: "mappin").font(.caption)
+                            }
+                            if let teacher = context.state.nextLessonTeacher {
+                                Label(teacher, systemImage: "person").font(.caption)
+                            }
+                            Spacer()
+                        case .dayEnd:
+                            Spacer()
+                        }
+                    }
+                }
+            } compactLeading: {
+                switch context.state.phase {
+                case .lesson:
+                    Text(String(context.attributes.lessonName.prefix(3))).font(.caption.bold())
+                case .break:
+                    Text(String((context.state.nextLessonName ?? "").prefix(3))).font(.caption.bold())
+                case .dayEnd:
+                    Text("—").font(.caption.bold())
+                }
+            } compactTrailing: {
+                switch context.state.phase {
+                case .lesson, .break:
+                    Text(timerInterval: Date()...context.state.phaseEndTime, countsDown: true)
+                        .font(.caption2.monospacedDigit())
+                        .frame(width: 40)
+                case .dayEnd:
+                    EmptyView()
+                }
+            } minimal: {
+                switch context.state.phase {
+                case .lesson:
+                    Text(String(context.attributes.lessonName.prefix(2)))
+                        .font(.system(size: 15, weight: .bold))
+                case .break:
+                    Text(String((context.state.nextLessonName ?? "").prefix(2)))
+                        .font(.system(size: 15, weight: .bold))
+                case .dayEnd:
+                    Image(systemName: "checkmark").font(.caption.bold())
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Previews
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview("Lock Screen – Lesson", as: .content, using: LessonActivityAttributes(
+    lessonName: "Mathematik",
+    teacher: "Müller",
+    room: "204"
+)) {
+    StundenLiveActivityWidget()
+} contentStates: {
+    LessonActivityAttributes.ContentState(
+        phase: .lesson,
+        phaseStartTime: Date().addingTimeInterval(-20 * 60),
+        phaseEndTime: Date().addingTimeInterval(25 * 60),
+        nextLessonName: "Deutsch",
+        nextLessonRoom: "101",
+        nextLessonTeacher: "Schmidt",
+        nextLessonStart: "09:30"
+    )
+}
+
+@available(iOS 17.0, *)
+#Preview("Lock Screen – Break", as: .content, using: LessonActivityAttributes(
+    lessonName: "Mathematik",
+    teacher: "Müller",
+    room: "204"
+)) {
+    StundenLiveActivityWidget()
+} contentStates: {
+    LessonActivityAttributes.ContentState(
+        phase: .break,
+        phaseStartTime: Date().addingTimeInterval(-3 * 60),
+        phaseEndTime: Date().addingTimeInterval(7 * 60),
+        nextLessonName: "Deutsch",
+        nextLessonRoom: "101",
+        nextLessonTeacher: "Schmidt",
+        nextLessonStart: "09:30"
+    )
+}
+
+@available(iOS 17.0, *)
+#Preview("Lock Screen – Day End", as: .content, using: LessonActivityAttributes(
+    lessonName: "Mathematik",
+    teacher: "Müller",
+    room: "204"
+)) {
+    StundenLiveActivityWidget()
+} contentStates: {
+    LessonActivityAttributes.ContentState(
+        phase: .dayEnd,
+        phaseStartTime: Date(),
+        phaseEndTime: Date().addingTimeInterval(50),
+        nextLessonName: nil,
+        nextLessonRoom: nil,
+        nextLessonTeacher: nil,
+        nextLessonStart: nil
+    )
+}
+
+@available(iOS 17.0, *)
+#Preview("Dynamic Island Expanded – Break", as: .dynamicIsland(.expanded), using: LessonActivityAttributes(
+    lessonName: "Mathematik",
+    teacher: "Müller",
+    room: "204"
+)) {
+    StundenLiveActivityWidget()
+} contentStates: {
+    LessonActivityAttributes.ContentState(
+        phase: .break,
+        phaseStartTime: Date().addingTimeInterval(-3 * 60),
+        phaseEndTime: Date().addingTimeInterval(7 * 60),
+        nextLessonName: "Deutsch",
+        nextLessonRoom: "101",
+        nextLessonTeacher: "Schmidt",
+        nextLessonStart: "09:30"
+    )
+}
+#endif

--- a/ios/LanisWidgets/StundenplanWidget.swift
+++ b/ios/LanisWidgets/StundenplanWidget.swift
@@ -1,0 +1,455 @@
+import WidgetKit
+import SwiftUI
+
+struct TimetableTimelineEntry: TimelineEntry {
+    let date: Date
+    let data: TimetableData?
+}
+
+struct TimetableProvider: TimelineProvider {
+    func placeholder(in context: Context) -> TimetableTimelineEntry {
+        TimetableTimelineEntry(date: Date(), data: nil)
+    }
+    func getSnapshot(in context: Context, completion: @escaping (TimetableTimelineEntry) -> Void) {
+        completion(TimetableTimelineEntry(date: Date(), data: WidgetDataReader.timetable()))
+    }
+    func getTimeline(in context: Context, completion: @escaping (Timeline<TimetableTimelineEntry>) -> Void) {
+        let entry = TimetableTimelineEntry(date: Date(), data: WidgetDataReader.timetable())
+        let next = Calendar.current.date(byAdding: .minute, value: 30, to: Date())!
+        completion(Timeline(entries: [entry], policy: .after(next)))
+    }
+}
+
+// MARK: - Shared helpers
+
+private func nowMinutes() -> Int {
+    let c = Calendar.current.dateComponents([.hour, .minute], from: Date())
+    return (c.hour ?? 0) * 60 + (c.minute ?? 0)
+}
+
+private func toMinutes(_ time: String) -> Int {
+    let parts = time.split(separator: ":").compactMap { Int($0) }
+    guard parts.count == 2 else { return 0 }
+    return parts[0] * 60 + parts[1]
+}
+
+private func progressInLesson(_ entry: TimetableEntry) -> Double {
+    let now = nowMinutes()
+    let start = toMinutes(entry.start)
+    let end = toMinutes(entry.end)
+    guard end > start else { return 0 }
+    return min(1, max(0, Double(now - start) / Double(end - start)))
+}
+
+private func isOngoing(_ entry: TimetableEntry) -> Bool {
+    let now = nowMinutes()
+    return now >= toMinutes(entry.start) && now < toMinutes(entry.end)
+}
+
+private func isUpcoming(_ entry: TimetableEntry) -> Bool {
+    return toMinutes(entry.start) > nowMinutes()
+}
+
+// Compute text color like the app: white on dark, black on light
+private func labelColor(for bg: Color) -> Color {
+    // SwiftUI Color doesn't expose luminance directly — use a heuristic via UIColor
+    let ui = UIColor(bg)
+    var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+    ui.getRed(&r, green: &g, blue: &b, alpha: &a)
+    let luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
+    return luminance > 0.5 ? .black : .white
+}
+
+// MARK: - Lesson block (mirrors app's ItemBlock)
+
+/// Replicates the app's colored rounded rectangle with name + teacher + room.
+@available(iOSApplicationExtension 16.0, *)
+private struct LessonBlock: View {
+    let entry: TimetableEntry
+    /// Height in points; nil = intrinsic
+    var fixedHeight: CGFloat? = nil
+    var showTime: Bool = true
+    var compact: Bool = false
+
+    private var bg: Color { entry.accentColor }
+    private var fg: Color { labelColor(for: bg) }
+
+    var body: some View {
+        ZStack(alignment: .bottomLeading) {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(bg)
+
+            // Progress bar overlay for ongoing lesson
+            if isOngoing(entry) {
+                GeometryReader { geo in
+                    VStack(spacing: 0) {
+                        Spacer(minLength: 0)
+                        RoundedRectangle(cornerRadius: 0)
+                            .fill(Color.black.opacity(0.15))
+                            .frame(height: geo.size.height * (1 - progressInLesson(entry)))
+                    }
+                }
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
+
+            VStack(alignment: .leading, spacing: compact ? 0 : 1) {
+                // Name + teacher row (same as app's Wrap)
+                HStack(alignment: .top) {
+                    Text(entry.name)
+                        .font(.system(size: compact ? 10 : 12, weight: .semibold))
+                        .foregroundStyle(fg)
+                        .lineLimit(1)
+                    Spacer(minLength: 2)
+                    if let teacher = entry.teacher, !compact {
+                        Text(teacher)
+                            .font(.system(size: 11))
+                            .foregroundStyle(fg.opacity(0.85))
+                            .lineLimit(1)
+                    }
+                }
+                if let room = entry.room {
+                    Text(room)
+                        .font(.system(size: compact ? 9 : 11))
+                        .foregroundStyle(fg.opacity(0.85))
+                        .lineLimit(1)
+                }
+                if showTime && !compact {
+                    Text("\(entry.start)–\(entry.end)")
+                        .font(.system(size: 10))
+                        .foregroundStyle(fg.opacity(0.7))
+                }
+            }
+            .padding(.horizontal, 5)
+            .padding(.vertical, 4)
+        }
+        .frame(height: fixedHeight)
+    }
+}
+
+// MARK: - Row with stunde indicator (mirrors app's left column + block)
+
+@available(iOSApplicationExtension 16.0, *)
+private struct LessonRow: View {
+    let entry: TimetableEntry
+    var highlightOngoing: Bool = true
+
+    private var ongoing: Bool { isOngoing(entry) }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 6) {
+            // Left: stunde + time (mirrors app's hourWidth column)
+            VStack(alignment: .trailing, spacing: 1) {
+                Text("\(entry.stunde).")
+                    .font(.system(size: 12, weight: ongoing ? .bold : .regular, design: .rounded))
+                    .foregroundStyle(ongoing ? Color.accentColor : .primary)
+                Text(entry.start)
+                    .font(.system(size: 10, design: .monospaced))
+                    .foregroundStyle(.secondary)
+            }
+            .frame(width: 38, alignment: .trailing)
+
+            // Right: colored block
+            LessonBlock(entry: entry, showTime: false)
+        }
+        .frame(maxWidth: .infinity)
+    }
+}
+
+// MARK: - Small: current/next lesson as a prominent block
+
+@available(iOSApplicationExtension 17.0, *)
+struct TimetableSmallView: View {
+    let data: TimetableData?
+
+    private var featured: TimetableEntry? {
+        data?.currentLesson ?? data?.today.first(where: { isUpcoming($0) })
+    }
+    private var next: TimetableEntry? {
+        guard let f = featured else { return nil }
+        let idx = data?.today.firstIndex(where: { $0.name == f.name && $0.start == f.start })
+        guard let i = idx, i + 1 < (data?.today.count ?? 0) else { return nil }
+        return data?.today[i + 1]
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            // Header: "Jetzt" / "Nächste"
+            HStack {
+                Text(featured != nil && isOngoing(featured!) ? "Jetzt" : "Nächste Stunde")
+                    .font(.caption2.bold())
+                    .foregroundStyle(Color.accentColor)
+                Spacer()
+                Text(Date(), style: .time)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+
+            if let lesson = featured {
+                LessonBlock(entry: lesson, fixedHeight: nil, showTime: true, compact: false)
+                    .frame(maxHeight: .infinity)
+            } else {
+                Spacer()
+                Text("Keine weiteren\nStunden heute")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: .infinity)
+                Spacer()
+            }
+
+            // Next lesson hint
+            if let n = next {
+                HStack(spacing: 4) {
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(n.accentColor)
+                        .frame(width: 3, height: 12)
+                    Text("Dann: \(n.name) · \(n.start)")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+        }
+        .padding(12)
+        .containerBackground(.fill.tertiary, for: .widget)
+    }
+}
+
+// MARK: - Medium: 3 lessons as rows (stunde + block)
+
+@available(iOSApplicationExtension 17.0, *)
+struct TimetableMediumView: View {
+    let data: TimetableData?
+
+    private var visible: [TimetableEntry] {
+        let all = data?.today ?? []
+        let now = nowMinutes()
+        // prefer ongoing + next 2, else next 3
+        let relevant = all.filter { toMinutes($0.end) > now }
+        return Array(relevant.prefix(3))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack {
+                Text("Stundenplan heute")
+                    .font(.caption2.bold())
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+
+            if visible.isEmpty {
+                Spacer()
+                Text("Keine weiteren Stunden heute")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                Spacer()
+            } else {
+                ForEach(visible.indices, id: \.self) { i in
+                    LessonRow(entry: visible[i])
+                }
+                Spacer(minLength: 0)
+            }
+        }
+        .padding(12)
+        .containerBackground(.fill.tertiary, for: .widget)
+    }
+}
+
+// MARK: - Large: all today's lessons
+
+@available(iOSApplicationExtension 17.0, *)
+struct TimetableLargeView: View {
+    let data: TimetableData?
+
+    private var lessons: [TimetableEntry] { data?.today ?? [] }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text("Stundenplan heute")
+                    .font(.caption.bold())
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+            Divider()
+
+            if lessons.isEmpty {
+                Spacer()
+                Text("Keine Stunden heute")
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                Spacer()
+            } else {
+                ForEach(lessons.indices, id: \.self) { i in
+                    LessonRow(entry: lessons[i])
+                }
+                Spacer(minLength: 0)
+            }
+        }
+        .padding(12)
+        .containerBackground(.fill.tertiary, for: .widget)
+    }
+}
+
+// MARK: - Lock Screen Views (unchanged)
+
+@available(iOSApplicationExtension 16.0, *)
+struct TimetableAccessoryCircularView: View {
+    let data: TimetableData?
+    var body: some View {
+        let name = data?.currentLesson?.name ?? data?.today.first(where: { isUpcoming($0) })?.name ?? "–"
+        let short = String(name.prefix(3))
+        ZStack {
+            AccessoryWidgetBackground()
+            Text(short)
+                .font(.caption.bold())
+                .widgetAccentable()
+        }
+    }
+}
+
+@available(iOSApplicationExtension 16.0, *)
+struct TimetableAccessoryRectangularView: View {
+    let data: TimetableData?
+    var body: some View {
+        let lesson = data?.currentLesson ?? data?.today.first(where: { isUpcoming($0) })
+        if let l = lesson {
+            VStack(alignment: .leading) {
+                Text(l.name).font(.headline).widgetAccentable()
+                Text("\(l.start) Uhr\(l.room.map { " · \($0)" } ?? "")").font(.caption)
+            }
+        } else {
+            Text("Keine Stunden").font(.caption)
+        }
+    }
+}
+
+@available(iOSApplicationExtension 16.0, *)
+struct TimetableAccessoryInlineView: View {
+    let data: TimetableData?
+    var body: some View {
+        let lesson = data?.currentLesson ?? data?.today.first(where: { isUpcoming($0) })
+        if let l = lesson {
+            Text("Jetzt: \(l.name)\(l.room.map { " \($0)" } ?? "")")
+        } else {
+            Text("Kein Unterricht")
+        }
+    }
+}
+
+// MARK: - Widget
+
+@available(iOSApplicationExtension 17.0, *)
+struct StundenplanWidget: Widget {
+    let kind = "StundenplanWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: TimetableProvider()) { entry in
+            StundenplanWidgetView(entry: entry)
+        }
+        .configurationDisplayName("Stundenplan")
+        .description("Zeigt deine heutigen Stunden.")
+        .supportedFamilies(supportedFamilies)
+    }
+
+    private var supportedFamilies: [WidgetFamily] {
+        var families: [WidgetFamily] = [.systemSmall, .systemMedium, .systemLarge]
+        if #available(iOSApplicationExtension 16.0, *) {
+            families += [.accessoryCircular, .accessoryRectangular, .accessoryInline]
+        }
+        return families
+    }
+}
+
+@available(iOSApplicationExtension 17.0, *)
+struct StundenplanWidgetView: View {
+    let entry: TimetableTimelineEntry
+    @Environment(\.widgetFamily) var family
+
+    var body: some View {
+        Group {
+            switch family {
+            case .systemSmall:
+                TimetableSmallView(data: entry.data)
+            case .systemMedium:
+                TimetableMediumView(data: entry.data)
+            case .systemLarge:
+                TimetableLargeView(data: entry.data)
+            default:
+                if #available(iOSApplicationExtension 16.0, *) {
+                    switch family {
+                    case .accessoryCircular:
+                        TimetableAccessoryCircularView(data: entry.data)
+                    case .accessoryRectangular:
+                        TimetableAccessoryRectangularView(data: entry.data)
+                    case .accessoryInline:
+                        TimetableAccessoryInlineView(data: entry.data)
+                    default:
+                        EmptyView()
+                    }
+                }
+            }
+        }
+        .widgetURL(URL(string: "lanis://applet/stundenplan.php")!)
+    }
+}
+
+// MARK: - Previews
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview("Small", as: .systemSmall) {
+    StundenplanWidget()
+} timeline: {
+    TimetableTimelineEntry(date: .now, data: TimetableData(
+        updatedAt: "",
+        today: [
+            TimetableEntry(name: "Mathematik", room: "204", teacher: "Müller", start: "07:55", end: "08:40", stunde: 1, color: "#E53935"),
+            TimetableEntry(name: "Deutsch", room: "101", teacher: "Koch", start: "08:45", end: "09:30", stunde: 2, color: "#1E88E5"),
+            TimetableEntry(name: "Englisch", room: "102", teacher: "Weber", start: "09:50", end: "10:35", stunde: 3, color: "#43A047"),
+            TimetableEntry(name: "Biologie", room: "301", teacher: "Fischer", start: "10:40", end: "11:25", stunde: 4, color: "#8E24AA"),
+            TimetableEntry(name: "Sport", room: "Halle", teacher: "Hoffmann", start: "11:40", end: "12:25", stunde: 5, color: "#FB8C00"),
+            TimetableEntry(name: "Musik", room: "103", teacher: "Braun", start: "12:30", end: "13:15", stunde: 6, color: "#00897B"),
+        ],
+        currentLesson: TimetableEntry(name: "Mathematik", room: "204", teacher: "Müller", start: "07:55", end: "08:40", stunde: 1, color: "#E53935")
+    ))
+}
+
+@available(iOS 17.0, *)
+#Preview("Medium", as: .systemMedium) {
+    StundenplanWidget()
+} timeline: {
+    TimetableTimelineEntry(date: .now, data: TimetableData(
+        updatedAt: "",
+        today: [
+            TimetableEntry(name: "Mathematik", room: "204", teacher: "Müller", start: "07:55", end: "08:40", stunde: 1, color: "#E53935"),
+            TimetableEntry(name: "Deutsch", room: "101", teacher: "Koch", start: "08:45", end: "09:30", stunde: 2, color: "#1E88E5"),
+            TimetableEntry(name: "Englisch", room: "102", teacher: "Weber", start: "09:50", end: "10:35", stunde: 3, color: "#43A047"),
+            TimetableEntry(name: "Biologie", room: "301", teacher: "Fischer", start: "10:40", end: "11:25", stunde: 4, color: "#8E24AA"),
+            TimetableEntry(name: "Sport", room: "Halle", teacher: "Hoffmann", start: "11:40", end: "12:25", stunde: 5, color: "#FB8C00"),
+            TimetableEntry(name: "Musik", room: "103", teacher: "Braun", start: "12:30", end: "13:15", stunde: 6, color: "#00897B"),
+        ],
+        currentLesson: TimetableEntry(name: "Mathematik", room: "204", teacher: "Müller", start: "07:55", end: "08:40", stunde: 1, color: "#E53935")
+    ))
+}
+
+@available(iOS 17.0, *)
+#Preview("Large", as: .systemLarge) {
+    StundenplanWidget()
+} timeline: {
+    TimetableTimelineEntry(date: .now, data: TimetableData(
+        updatedAt: "",
+        today: [
+            TimetableEntry(name: "Mathematik", room: "204", teacher: "Müller", start: "07:55", end: "08:40", stunde: 1, color: "#E53935"),
+            TimetableEntry(name: "Deutsch", room: "101", teacher: "Koch", start: "08:45", end: "09:30", stunde: 2, color: "#1E88E5"),
+            TimetableEntry(name: "Englisch", room: "102", teacher: "Weber", start: "09:50", end: "10:35", stunde: 3, color: "#43A047"),
+            TimetableEntry(name: "Biologie", room: "301", teacher: "Fischer", start: "10:40", end: "11:25", stunde: 4, color: "#8E24AA"),
+            TimetableEntry(name: "Sport", room: "Halle", teacher: "Hoffmann", start: "11:40", end: "12:25", stunde: 5, color: "#FB8C00"),
+            TimetableEntry(name: "Musik", room: "103", teacher: "Braun", start: "12:30", end: "13:15", stunde: 6, color: "#00897B"),
+        ],
+        currentLesson: nil
+    ))
+}
+#endif

--- a/ios/LanisWidgets/VertretungsWidget.swift
+++ b/ios/LanisWidgets/VertretungsWidget.swift
@@ -1,0 +1,216 @@
+import WidgetKit
+import SwiftUI
+
+struct SubstitutionTimelineEntry: TimelineEntry {
+    let date: Date
+    let data: SubstitutionData?
+}
+
+struct SubstitutionProvider: TimelineProvider {
+    func placeholder(in context: Context) -> SubstitutionTimelineEntry {
+        SubstitutionTimelineEntry(date: Date(), data: nil)
+    }
+    func getSnapshot(in context: Context, completion: @escaping (SubstitutionTimelineEntry) -> Void) {
+        completion(SubstitutionTimelineEntry(date: Date(), data: WidgetDataReader.substitutions()))
+    }
+    func getTimeline(in context: Context, completion: @escaping (Timeline<SubstitutionTimelineEntry>) -> Void) {
+        let entry = SubstitutionTimelineEntry(date: Date(), data: WidgetDataReader.substitutions())
+        let next = Calendar.current.date(byAdding: .minute, value: 30, to: Date())!
+        completion(Timeline(entries: [entry], policy: .after(next)))
+    }
+}
+
+@available(iOSApplicationExtension 17.0, *)
+struct VertretungsSmallView: View {
+    let data: SubstitutionData?
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Image("AppIcon").resizable().frame(width: 20, height: 20).clipShape(RoundedRectangle(cornerRadius: 4))
+                Text("Vertretung").font(.caption2).foregroundStyle(.secondary)
+            }
+            Spacer()
+            let count = data?.entries.count ?? 0
+            Text("\(count)").font(.system(size: 36, weight: .bold)).foregroundStyle(count > 0 ? Color.red : Color.secondary)
+            Text(count == 1 ? "Vertretung" : "Vertretungen").font(.caption).foregroundStyle(.secondary)
+            if let first = data?.entries.first {
+                Text("\(first.stunde). Std · \(first.art ?? "")").font(.caption2).foregroundStyle(.tertiary).lineLimit(1)
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+        .containerBackground(.fill.tertiary, for: .widget)
+    }
+}
+
+@available(iOSApplicationExtension 17.0, *)
+struct VertretungsMediumView: View {
+    let data: SubstitutionData?
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Image("AppIcon").resizable().frame(width: 16, height: 16).clipShape(RoundedRectangle(cornerRadius: 3))
+                Text("Vertretungen").font(.caption2).foregroundStyle(.secondary)
+                Spacer()
+                if let date = data?.date { Text(date).font(.caption2).foregroundStyle(.tertiary) }
+            }
+            let entries = Array((data?.entries ?? []).prefix(3))
+            if entries.isEmpty {
+                Spacer()
+                Text("Keine Vertretungen").font(.subheadline).foregroundStyle(.secondary)
+                Spacer()
+            } else {
+                ForEach(entries.indices, id: \.self) { i in
+                    let e = entries[i]
+                    HStack(spacing: 6) {
+                        Text("\(e.stunde).")
+                            .font(.caption.monospacedDigit()).bold()
+                            .frame(width: 20, alignment: .trailing)
+                        Text(e.fach ?? "–").font(.subheadline).lineLimit(1)
+                        Spacer()
+                        Text(e.art ?? "").font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+                Spacer()
+            }
+        }
+        .padding()
+        .containerBackground(.fill.tertiary, for: .widget)
+    }
+}
+
+@available(iOSApplicationExtension 17.0, *)
+struct VertretungsLargeView: View {
+    let data: SubstitutionData?
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Image("AppIcon").resizable().frame(width: 18, height: 18).clipShape(RoundedRectangle(cornerRadius: 4))
+                Text("Vertretungen heute").font(.caption).foregroundStyle(.secondary)
+                Spacer()
+                if let date = data?.date { Text(date).font(.caption2).foregroundStyle(.tertiary) }
+            }
+            Divider()
+            let entries = data?.entries ?? []
+            if entries.isEmpty {
+                Spacer()
+                Text("Keine Vertretungen").foregroundStyle(.secondary)
+                Spacer()
+            } else {
+                ForEach(entries.indices, id: \.self) { i in
+                    let e = entries[i]
+                    HStack(spacing: 8) {
+                        Text("\(e.stunde).")
+                            .font(.caption2.monospacedDigit()).bold()
+                            .frame(width: 20, alignment: .trailing)
+                        VStack(alignment: .leading, spacing: 0) {
+                            Text(e.fach ?? "–").font(.subheadline).bold().lineLimit(1)
+                            HStack(spacing: 4) {
+                                if let art = e.art { Text(art).font(.caption2).foregroundStyle(.red) }
+                                if let raum = e.raum { Text("→ \(raum)").font(.caption2).foregroundStyle(.secondary) }
+                                if let v = e.vertreter { Text(v).font(.caption2).foregroundStyle(.secondary) }
+                            }
+                        }
+                        Spacer()
+                    }
+                }
+            }
+            Spacer()
+        }
+        .padding()
+        .containerBackground(.fill.tertiary, for: .widget)
+    }
+}
+
+@available(iOSApplicationExtension 17.0, *)
+struct VertretungsWidget: Widget {
+    let kind = "VertretungsWidget"
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: SubstitutionProvider()) { entry in
+            VertretungsWidgetView(entry: entry)
+        }
+        .configurationDisplayName("Vertretungen")
+        .description("Zeigt deine heutigen Vertretungen.")
+        .supportedFamilies(supportedFamilies)
+    }
+    private var supportedFamilies: [WidgetFamily] {
+        var f: [WidgetFamily] = [.systemSmall, .systemMedium, .systemLarge]
+        if #available(iOSApplicationExtension 16.0, *) { f += [.accessoryCircular, .accessoryRectangular, .accessoryInline] }
+        return f
+    }
+}
+
+@available(iOSApplicationExtension 17.0, *)
+struct VertretungsWidgetView: View {
+    let entry: SubstitutionTimelineEntry
+    @Environment(\.widgetFamily) var family
+    var body: some View {
+        Group {
+            switch family {
+            case .systemSmall: VertretungsSmallView(data: entry.data)
+            case .systemMedium: VertretungsMediumView(data: entry.data)
+            case .systemLarge: VertretungsLargeView(data: entry.data)
+            default:
+                if #available(iOSApplicationExtension 16.0, *) {
+                    let count = entry.data?.entries.count ?? 0
+                    switch family {
+                    case .accessoryCircular:
+                        ZStack {
+                            AccessoryWidgetBackground()
+                            Text("\(count)").font(.headline.bold()).widgetAccentable()
+                        }
+                    case .accessoryRectangular:
+                        VStack(alignment: .leading) {
+                            if let first = entry.data?.entries.first {
+                                Text("\(first.stunde). Std · \(first.art ?? "")").font(.headline).widgetAccentable()
+                                Text(first.fach ?? "–").font(.caption)
+                            } else {
+                                Text("Keine Vertretungen").font(.caption)
+                            }
+                        }
+                    case .accessoryInline:
+                        Text(count > 0 ? "\(count) Vertretung\(count == 1 ? "" : "en") heute" : "Keine Vertretungen")
+                    default: EmptyView()
+                    }
+                }
+            }
+        }
+        .widgetURL(URL(string: "lanis://applet/vertretungsplan.php")!)
+    }
+}
+
+// MARK: - Previews
+
+#if DEBUG
+private let previewSubData = SubstitutionData(
+    updatedAt: "",
+    date: "03.06.2026",
+    entries: [
+        SubstitutionEntry(stunde: "3", fach: "Mathematik", art: "Vertretung", raum: "204", vertreter: "Schmidt"),
+        SubstitutionEntry(stunde: "5", fach: "Englisch", art: "Ausfall", raum: nil, vertreter: nil),
+        SubstitutionEntry(stunde: "6", fach: "Sport", art: "Raumänderung", raum: "Halle 2", vertreter: "Hoffmann"),
+    ]
+)
+
+@available(iOS 17.0, *)
+#Preview("Small", as: .systemSmall) {
+    VertretungsWidget()
+} timeline: {
+    SubstitutionTimelineEntry(date: .now, data: previewSubData)
+}
+
+@available(iOS 17.0, *)
+#Preview("Medium", as: .systemMedium) {
+    VertretungsWidget()
+} timeline: {
+    SubstitutionTimelineEntry(date: .now, data: previewSubData)
+}
+
+@available(iOS 17.0, *)
+#Preview("Large", as: .systemLarge) {
+    VertretungsWidget()
+} timeline: {
+    SubstitutionTimelineEntry(date: .now, data: previewSubData)
+}
+#endif
+

--- a/ios/LanisWidgets/WidgetDataReader.swift
+++ b/ios/LanisWidgets/WidgetDataReader.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+struct WidgetDataReader {
+    private static let defaults = UserDefaults(suiteName: appGroupID)
+
+    static func timetable() -> TimetableData? {
+        decode(key: "widget_timetable")
+    }
+
+    static func substitutions() -> SubstitutionData? {
+        decode(key: "widget_substitutions")
+    }
+
+    static func calendar() -> CalendarData? {
+        decode(key: "widget_calendar")
+    }
+
+    static func conversations() -> ConversationsData? {
+        decode(key: "widget_conversations")
+    }
+
+    private static func decode<T: Decodable>(key: String) -> T? {
+        guard let jsonString = defaults?.string(forKey: key),
+              let data = jsonString.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(T.self, from: data)
+    }
+}

--- a/ios/LanisWidgetsExtension.entitlements
+++ b/ios/LanisWidgetsExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.io.github.alessioc42.sph.widgets</string>
+	</array>
+</dict>
+</plist>

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -28,7 +28,7 @@ require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelpe
 flutter_ios_podfile_setup
 
 target 'Runner' do
-  use_frameworks! # :linkage => :static
+  use_frameworks! :linkage => :static
   use_modular_headers!
 
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,8 +1,9 @@
 PODS:
   - app_settings (6.1.2):
     - Flutter
-  - background_fetch (1.4.0):
+  - background_fetch (1.7.0):
     - Flutter
+    - TSBackgroundFetch (~> 4.1.0)
   - cupertino_http (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -47,8 +48,6 @@ PODS:
     - Flutter
   - flutter_doc_scanner (0.0.1):
     - Flutter
-  - flutter_email_sender (0.0.1):
-    - Flutter
   - flutter_inappwebview_ios (0.0.1):
     - Flutter
     - flutter_inappwebview_ios/Core (= 0.0.1)
@@ -56,8 +55,6 @@ PODS:
   - flutter_inappwebview_ios/Core (0.0.1):
     - Flutter
     - OrderedSet (~> 6.0.3)
-  - flutter_keyboard_visibility (0.0.1):
-    - Flutter
   - flutter_keyboard_visibility_temp_fork (0.0.1):
     - Flutter
   - flutter_local_notifications (0.0.1):
@@ -74,9 +71,11 @@ PODS:
   - OrderedSet (6.0.3)
   - package_info_plus (0.4.5):
     - Flutter
-  - permission_handler_apple (9.3.0):
+  - permission_handler_apple (9.4.8):
     - Flutter
   - quick_actions_ios (0.0.1):
+    - Flutter
+  - quill_native_bridge_ios (0.0.1):
     - Flutter
   - SDWebImage (5.21.5):
     - SDWebImage/Core (= 5.21.5)
@@ -86,32 +85,8 @@ PODS:
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - sqlite3 (3.51.1):
-    - sqlite3/common (= 3.51.1)
-  - sqlite3/common (3.51.1)
-  - sqlite3/dbstatvtab (3.51.1):
-    - sqlite3/common
-  - sqlite3/fts5 (3.51.1):
-    - sqlite3/common
-  - sqlite3/math (3.51.1):
-    - sqlite3/common
-  - sqlite3/perf-threadsafe (3.51.1):
-    - sqlite3/common
-  - sqlite3/rtree (3.51.1):
-    - sqlite3/common
-  - sqlite3/session (3.51.1):
-    - sqlite3/common
-  - sqlite3_flutter_libs (0.0.1):
-    - Flutter
-    - FlutterMacOS
-    - sqlite3 (~> 3.51.1)
-    - sqlite3/dbstatvtab
-    - sqlite3/fts5
-    - sqlite3/math
-    - sqlite3/perf-threadsafe
-    - sqlite3/rtree
-    - sqlite3/session
   - SwiftyGif (5.4.5)
+  - TSBackgroundFetch (4.1.1)
   - url_launcher_ios (0.0.1):
     - Flutter
 
@@ -124,9 +99,7 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_background_executor (from `.symlinks/plugins/flutter_background_executor/ios`)
   - flutter_doc_scanner (from `.symlinks/plugins/flutter_doc_scanner/ios`)
-  - flutter_email_sender (from `.symlinks/plugins/flutter_email_sender/ios`)
   - flutter_inappwebview_ios (from `.symlinks/plugins/flutter_inappwebview_ios/ios`)
-  - flutter_keyboard_visibility (from `.symlinks/plugins/flutter_keyboard_visibility/ios`)
   - flutter_keyboard_visibility_temp_fork (from `.symlinks/plugins/flutter_keyboard_visibility_temp_fork/ios`)
   - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
@@ -136,9 +109,9 @@ DEPENDENCIES:
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - quick_actions_ios (from `.symlinks/plugins/quick_actions_ios/ios`)
+  - quill_native_bridge_ios (from `.symlinks/plugins/quill_native_bridge_ios/ios`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
-  - sqlite3_flutter_libs (from `.symlinks/plugins/sqlite3_flutter_libs/darwin`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 SPEC REPOS:
@@ -147,8 +120,8 @@ SPEC REPOS:
     - DKPhotoGallery
     - OrderedSet
     - SDWebImage
-    - sqlite3
     - SwiftyGif
+    - TSBackgroundFetch
 
 EXTERNAL SOURCES:
   app_settings:
@@ -167,12 +140,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_background_executor/ios"
   flutter_doc_scanner:
     :path: ".symlinks/plugins/flutter_doc_scanner/ios"
-  flutter_email_sender:
-    :path: ".symlinks/plugins/flutter_email_sender/ios"
   flutter_inappwebview_ios:
     :path: ".symlinks/plugins/flutter_inappwebview_ios/ios"
-  flutter_keyboard_visibility:
-    :path: ".symlinks/plugins/flutter_keyboard_visibility/ios"
   flutter_keyboard_visibility_temp_fork:
     :path: ".symlinks/plugins/flutter_keyboard_visibility_temp_fork/ios"
   flutter_local_notifications:
@@ -191,47 +160,45 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
   quick_actions_ios:
     :path: ".symlinks/plugins/quick_actions_ios/ios"
+  quill_native_bridge_ios:
+    :path: ".symlinks/plugins/quill_native_bridge_ios/ios"
   share_plus:
     :path: ".symlinks/plugins/share_plus/ios"
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
-  sqlite3_flutter_libs:
-    :path: ".symlinks/plugins/sqlite3_flutter_libs/darwin"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
   app_settings: 0341ec6daa4f0c50f5a421bf0ad7c36084db6e90
-  background_fetch: 81d0f20490f0126a1c29709e458f47a69e80f44e
+  background_fetch: b273c4b6911fc2e309790b46b5658b7edc40b73b
   cupertino_http: 94ac07f5ff090b8effa6c5e2c47871d48ab7c86c
-  device_info_plus: 71ffc6ab7634ade6267c7a93088ed7e4f74e5896
+  device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
   DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
   file_picker: a0560bc09d61de87f12d246fc47d2119e6ef37be
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_background_executor: 8896055e67e989e9e1c02d84884b0dfaf9acce82
   flutter_doc_scanner: d930bcd7db6f69805d882330fc9b6f74a9db5c9e
-  flutter_email_sender: aa1e9772696691d02cd91fea829856c11efb8e58
   flutter_inappwebview_ios: b89ba3482b96fb25e00c967aae065701b66e9b99
-  flutter_keyboard_visibility: 4625131e43015dbbe759d9b20daaf77e0e3f6619
   flutter_keyboard_visibility_temp_fork: 95b2d534bacf6ac62e7fcbe5c2a9e2c2a17ce06f
-  flutter_local_notifications: a5a732f069baa862e728d839dd2ebb904737effb
+  flutter_local_notifications: 643a3eda1ce1c0599413ca31672536d423dee214
   flutter_native_splash: c32d145d68aeda5502d5f543ee38c192065986cf
   flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
   image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
   open_file_ios: 46184d802ee7959203f6392abcfa0dd49fdb5be0
   OrderedSet: e539b66b644ff081c73a262d24ad552a69be3a94
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
-  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
+  permission_handler_apple: 92d754bbaa7361d436db2d6c3c1c2a0fdcec462e
   quick_actions_ios: 500fcc11711d9f646739093395c4ae8eec25f779
+  quill_native_bridge_ios: f47af4b14e7757968486641656c5d23250cee521
   SDWebImage: e9c98383c7572d713c1a0d7dd2783b10599b9838
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
-  sqlite3: 8d708bc63e9f4ce48f0ad9d6269e478c5ced1d9b
-  sqlite3_flutter_libs: d13b8b3003f18f596e542bcb9482d105577eff41
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
+  TSBackgroundFetch: 18918b6449a1e3f01eb0f5b44d6d79ce6160a5a5
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
 
-PODFILE CHECKSUM: 29bd02bad900581c7884e1dee9851661d2fe88bb
+PODFILE CHECKSUM: c118466e7060795d729c5fb7c4b52d8413b88c0f
 
 COCOAPODS: 1.16.2

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -3,18 +3,25 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		0817F646D6554A1D117BD3C2 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 21587CA1D45F422C41AD738B /* Pods_Runner.framework */; };
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
+		3997A72D2FD05836007F29CB /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3997A72C2FD05836007F29CB /* WidgetKit.framework */; };
+		3997A72F2FD05836007F29CB /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3997A72E2FD05836007F29CB /* SwiftUI.framework */; };
+		3997A7402FD05839007F29CB /* LanisWidgetsExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 3997A72B2FD05836007F29CB /* LanisWidgetsExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		A1B2C3D4E5F60001A1B2C3D4 /* WidgetChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60002A1B2C3D4 /* WidgetChannel.swift */; };
+		B2C3D4E5F6A70001B2C3D4E5 /* LiveActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F6A70002B2C3D4E5 /* LiveActivityAttributes.swift */; };
+		B2C3D4E5F6A70003B2C3D4E5 /* LessonActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F6A70004B2C3D4E5 /* LessonActivityManager.swift */; };
+		B2C3D4E5F6A70005B2C3D4E5 /* SubstitutionActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F6A70006B2C3D4E5 /* SubstitutionActivityManager.swift */; };
 		C0347C87CBA4E0F051F9608D /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E906A899AD093DCB38781216 /* Pods_RunnerTests.framework */; };
 /* End PBXBuildFile section */
 
@@ -26,9 +33,27 @@
 			remoteGlobalIDString = 97C146ED1CF9000F007C117D;
 			remoteInfo = Runner;
 		};
+		3997A73E2FD05839007F29CB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3997A72A2FD05836007F29CB;
+			remoteInfo = LanisWidgetsExtension;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		3997A7412FD05839007F29CB /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				3997A7402FD05839007F29CB /* LanisWidgetsExtension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9705A1C41CF9048500538489 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -49,6 +74,11 @@
 		279A31D3159DC51225841F2C /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		3997A72B2FD05836007F29CB /* LanisWidgetsExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = LanisWidgetsExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		3997A72C2FD05836007F29CB /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
+		3997A72E2FD05836007F29CB /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
+		3997A7472FD05879007F29CB /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
+		3997A7482FD058AD007F29CB /* LanisWidgetsExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = LanisWidgetsExtension.entitlements; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		4068F2DE2D5E94600077F146 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		4CE1E918C6996A0021E0E7AC /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
@@ -63,12 +93,39 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A1B2C3D4E5F60002A1B2C3D4 /* WidgetChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetChannel.swift; sourceTree = "<group>"; };
+		B2C3D4E5F6A70002B2C3D4E5 /* LiveActivityAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityAttributes.swift; sourceTree = "<group>"; };
+		B2C3D4E5F6A70004B2C3D4E5 /* LessonActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LessonActivityManager.swift; sourceTree = "<group>"; };
+		B2C3D4E5F6A70006B2C3D4E5 /* SubstitutionActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubstitutionActivityManager.swift; sourceTree = "<group>"; };
 		C69B9A5F3614BFB0E21AE213 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		E906A899AD093DCB38781216 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FDFE0D5C0BF39DEDFE6E3363 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		3997A7452FD05839007F29CB /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 3997A72A2FD05836007F29CB /* LanisWidgetsExtension */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		3997A7302FD05836007F29CB /* LanisWidgets */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (3997A7452FD05839007F29CB /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = LanisWidgets; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXFrameworksBuildPhase section */
+		3997A7282FD05836007F29CB /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3997A72F2FD05836007F29CB /* SwiftUI.framework in Frameworks */,
+				3997A72D2FD05836007F29CB /* WidgetKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		97C146EB1CF9000F007C117D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -123,8 +180,10 @@
 		97C146E51CF9000F007C117D = {
 			isa = PBXGroup;
 			children = (
+				3997A7482FD058AD007F29CB /* LanisWidgetsExtension.entitlements */,
 				9740EEB11CF90186004384FC /* Flutter */,
 				97C146F01CF9000F007C117D /* Runner */,
+				3997A7302FD05836007F29CB /* LanisWidgets */,
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
 				67709B3E53CD082EA959644C /* Pods */,
@@ -137,6 +196,7 @@
 			children = (
 				97C146EE1CF9000F007C117D /* Runner.app */,
 				331C8081294A63A400263BE5 /* RunnerTests.xctest */,
+				3997A72B2FD05836007F29CB /* LanisWidgetsExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -144,6 +204,7 @@
 		97C146F01CF9000F007C117D /* Runner */ = {
 			isa = PBXGroup;
 			children = (
+				3997A7472FD05879007F29CB /* Runner.entitlements */,
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
@@ -151,6 +212,10 @@
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
+				A1B2C3D4E5F60002A1B2C3D4 /* WidgetChannel.swift */,
+				B2C3D4E5F6A70002B2C3D4E5 /* LiveActivityAttributes.swift */,
+				B2C3D4E5F6A70004B2C3D4E5 /* LessonActivityManager.swift */,
+				B2C3D4E5F6A70006B2C3D4E5 /* SubstitutionActivityManager.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
 				4068F2DE2D5E94600077F146 /* PrivacyInfo.xcprivacy */,
 			);
@@ -162,6 +227,8 @@
 			children = (
 				21587CA1D45F422C41AD738B /* Pods_Runner.framework */,
 				E906A899AD093DCB38781216 /* Pods_RunnerTests.framework */,
+				3997A72C2FD05836007F29CB /* WidgetKit.framework */,
+				3997A72E2FD05836007F29CB /* SwiftUI.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -188,6 +255,26 @@
 			productReference = 331C8081294A63A400263BE5 /* RunnerTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		3997A72A2FD05836007F29CB /* LanisWidgetsExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3997A7462FD05839007F29CB /* Build configuration list for PBXNativeTarget "LanisWidgetsExtension" */;
+			buildPhases = (
+				3997A7272FD05836007F29CB /* Sources */,
+				3997A7282FD05836007F29CB /* Frameworks */,
+				3997A7292FD05836007F29CB /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				3997A7302FD05836007F29CB /* LanisWidgets */,
+			);
+			name = LanisWidgetsExtension;
+			productName = LanisWidgetsExtension;
+			productReference = 3997A72B2FD05836007F29CB /* LanisWidgetsExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		97C146ED1CF9000F007C117D /* Runner */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
@@ -198,13 +285,14 @@
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
+				3997A7412FD05839007F29CB /* Embed Foundation Extensions */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				363FF3C8308604CBA222411E /* [CP] Copy Pods Resources */,
-				5C62358BAD52A8E33ABFD7D3 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				3997A73F2FD05839007F29CB /* PBXTargetDependency */,
 			);
 			name = Runner;
 			productName = Runner;
@@ -218,12 +306,16 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastUpgradeCheck = 1510;
+				LastSwiftUpdateCheck = 2650;
+				LastUpgradeCheck = 2650;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					331C8080294A63A400263BE5 = {
 						CreatedOnToolsVersion = 14.0;
 						TestTargetID = 97C146ED1CF9000F007C117D;
+					};
+					3997A72A2FD05836007F29CB = {
+						CreatedOnToolsVersion = 26.5;
 					};
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
@@ -246,12 +338,20 @@
 			targets = (
 				97C146ED1CF9000F007C117D /* Runner */,
 				331C8080294A63A400263BE5 /* RunnerTests */,
+				3997A72A2FD05836007F29CB /* LanisWidgetsExtension */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		331C807F294A63A400263BE5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3997A7292FD05836007F29CB /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -280,9 +380,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -304,23 +408,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
-		};
-		5C62358BAD52A8E33ABFD7D3 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -392,11 +479,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		3997A7272FD05836007F29CB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		97C146EA1CF9000F007C117D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
+				A1B2C3D4E5F60001A1B2C3D4 /* WidgetChannel.swift in Sources */,
+				B2C3D4E5F6A70001B2C3D4E5 /* LiveActivityAttributes.swift in Sources */,
+				B2C3D4E5F6A70003B2C3D4E5 /* LessonActivityManager.swift in Sources */,
+				B2C3D4E5F6A70005B2C3D4E5 /* SubstitutionActivityManager.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -408,6 +506,11 @@
 			isa = PBXTargetDependency;
 			target = 97C146ED1CF9000F007C117D /* Runner */;
 			targetProxy = 331C8085294A63A400263BE5 /* PBXContainerItemProxy */;
+		};
+		3997A73F2FD05839007F29CB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3997A72A2FD05836007F29CB /* LanisWidgetsExtension */;
+			targetProxy = 3997A73E2FD05839007F29CB /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -454,6 +557,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -475,6 +579,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -487,13 +592,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = H9TZCZZ47G;
+				DEVELOPMENT_TEAM = A4HCRKN53K;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -561,6 +667,141 @@
 			};
 			name = Profile;
 		};
+		3997A7422FD05839007F29CB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = LanisWidgetsExtension.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = A4HCRKN53K;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = LanisWidgets/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = LanisWidgets;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = io.github.alessioc42.sph.widgets;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		3997A7432FD05839007F29CB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = LanisWidgetsExtension.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = A4HCRKN53K;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = LanisWidgets/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = LanisWidgets;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = io.github.alessioc42.sph.widgets;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		3997A7442FD05839007F29CB /* Profile */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = LanisWidgetsExtension.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = A4HCRKN53K;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = LanisWidgets/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = LanisWidgets;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = io.github.alessioc42.sph.widgets;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Profile;
+		};
 		97C147031CF9000F007C117D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -584,6 +825,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -612,6 +854,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -639,6 +882,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -660,6 +904,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
@@ -674,13 +919,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = H9TZCZZ47G;
+				DEVELOPMENT_TEAM = A4HCRKN53K;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -701,13 +947,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = H9TZCZZ47G;
+				DEVELOPMENT_TEAM = A4HCRKN53K;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -731,6 +978,16 @@
 				331C8088294A63A400263BE5 /* Debug */,
 				331C8089294A63A400263BE5 /* Release */,
 				331C808A294A63A400263BE5 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3997A7462FD05839007F29CB /* Build configuration list for PBXNativeTarget "LanisWidgetsExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3997A7422FD05839007F29CB /* Debug */,
+				3997A7432FD05839007F29CB /* Release */,
+				3997A7442FD05839007F29CB /* Profile */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1510"
+   LastUpgradeVersion = "2650"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,9 +1,12 @@
 import UIKit
 import Flutter
 import flutter_local_notifications
+import ActivityKit
 
 @main
 @objc class AppDelegate: FlutterAppDelegate {
+  static var pendingWidgetURL: String? = nil
+
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
@@ -18,6 +21,35 @@ import flutter_local_notifications
       GeneratedPluginRegistrant.register(with: registry)
     }
 
+    if let controller = window?.rootViewController as? FlutterViewController {
+        WidgetChannel.register(with: controller)
+    }
+
+    // End any orphaned substitution live activities left over from a previous
+    // app version that still had the VertretungsLiveActivityWidget registered.
+    if #available(iOS 16.2, *) {
+        Task {
+            for activity in Activity<SubstitutionActivityAttributes>.activities {
+                await activity.end(dismissalPolicy: .immediate)
+            }
+            for activity in Activity<LessonActivityAttributes>.activities {
+                await activity.end(dismissalPolicy: .immediate)
+            }
+        }
+    }
+
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  override func application(
+    _ app: UIApplication,
+    open url: URL,
+    options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+  ) -> Bool {
+    if url.scheme == "lanis" {
+      AppDelegate.pendingWidgetURL = url.absoluteString
+      return true
+    }
+    return super.application(app, open: url, options: options)
   }
 }

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -69,5 +69,20 @@
 	<true/>
 	<key>NSCameraUsageDescription</key>
 	<string>Required when uploading a camera photo to Lanis</string>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
+	<key>NSSupportsLiveActivitiesFrequentUpdates</key>
+	<true/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>lanis</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/ios/Runner/LessonActivityManager.swift
+++ b/ios/Runner/LessonActivityManager.swift
@@ -1,0 +1,134 @@
+import ActivityKit
+import Flutter
+import Foundation
+
+@available(iOS 16.2, *)
+struct LessonJson: Decodable {
+    let name: String
+    let room: String?
+    let teacher: String?
+    let phase: String          // "lesson" | "break" | "dayEnd"
+    let phaseStartTime: String // "HH:mm"
+    let phaseEndTime: String   // "HH:mm"
+    let nextName: String?
+    let nextRoom: String?
+    let nextTeacher: String?
+    let nextStart: String?
+}
+
+@available(iOS 16.2, *)
+enum LessonActivityManager {
+    private static var currentActivity: Activity<LessonActivityAttributes>?
+
+    static func start(json: String, result: @escaping FlutterResult) {
+        guard let data = json.data(using: .utf8),
+              let lesson = try? JSONDecoder().decode(LessonJson.self, from: data),
+              let phase = ActivityPhase(rawValue: lesson.phase),
+              let startDate = parseTime(lesson.phaseStartTime),
+              let endDate = parseTime(lesson.phaseEndTime)
+        else {
+            result(FlutterError(code: "PARSE_ERROR", message: "Could not parse lesson json", details: nil))
+            return
+        }
+
+        // Adjust for midnight crossing: if endDate is before startDate, add one day
+        var adjustedEndDate = endDate
+        if adjustedEndDate < startDate {
+            adjustedEndDate = Calendar.current.date(byAdding: .day, value: 1, to: adjustedEndDate) ?? adjustedEndDate
+        }
+
+        let attrs = LessonActivityAttributes(
+            lessonName: lesson.name,
+            teacher: lesson.teacher,
+            room: lesson.room
+        )
+        let state = LessonActivityAttributes.ContentState(
+            phase: phase,
+            phaseStartTime: startDate,
+            phaseEndTime: adjustedEndDate,
+            nextLessonName: lesson.nextName,
+            nextLessonRoom: lesson.nextRoom,
+            nextLessonTeacher: lesson.nextTeacher,
+            nextLessonStart: lesson.nextStart
+        )
+
+        Task {
+            if let existing = currentActivity {
+                await existing.end(dismissalPolicy: .immediate)
+                currentActivity = nil
+            }
+            do {
+                currentActivity = try Activity.request(
+                    attributes: attrs,
+                    contentState: state,
+                    pushType: nil
+                )
+                DispatchQueue.main.async { result(nil) }
+            } catch {
+                DispatchQueue.main.async {
+                    result(FlutterError(code: "ACTIVITY_ERROR", message: error.localizedDescription, details: nil))
+                }
+            }
+        }
+    }
+
+    private static func existingActivity() -> Activity<LessonActivityAttributes>? {
+        Activity<LessonActivityAttributes>.activities.first
+    }
+
+    static func update(json: String, result: @escaping FlutterResult) {
+        guard let activity = currentActivity ?? existingActivity(),
+              let data = json.data(using: .utf8),
+              let lesson = try? JSONDecoder().decode(LessonJson.self, from: data),
+              let phase = ActivityPhase(rawValue: lesson.phase),
+              let startDate = parseTime(lesson.phaseStartTime),
+              let endDate = parseTime(lesson.phaseEndTime)
+        else {
+            result(nil)
+            return
+        }
+
+        // Adjust for midnight crossing: if endDate is before startDate, add one day
+        var adjustedEndDate = endDate
+        if adjustedEndDate < startDate {
+            adjustedEndDate = Calendar.current.date(byAdding: .day, value: 1, to: adjustedEndDate) ?? adjustedEndDate
+        }
+
+        let state = LessonActivityAttributes.ContentState(
+            phase: phase,
+            phaseStartTime: startDate,
+            phaseEndTime: adjustedEndDate,
+            nextLessonName: lesson.nextName,
+            nextLessonRoom: lesson.nextRoom,
+            nextLessonTeacher: lesson.nextTeacher,
+            nextLessonStart: lesson.nextStart
+        )
+        Task {
+            await activity.update(using: state)
+            DispatchQueue.main.async { result(nil) }
+        }
+    }
+
+    static func end(result: @escaping FlutterResult) {
+        guard let activity = currentActivity ?? existingActivity() else {
+            result(nil)
+            return
+        }
+        currentActivity = nil
+        Task {
+            await activity.end(dismissalPolicy: .immediate)
+            DispatchQueue.main.async { result(nil) }
+        }
+    }
+
+    private static func parseTime(_ timeString: String) -> Date? {
+        let parts = timeString.split(separator: ":").compactMap { Int($0) }
+        guard parts.count == 2 else { return nil }
+        let calendar = Calendar.current
+        var components = calendar.dateComponents([.year, .month, .day], from: Date())
+        components.hour = parts[0]
+        components.minute = parts[1]
+        components.second = 0
+        return calendar.date(from: components)
+    }
+}

--- a/ios/Runner/LiveActivityAttributes.swift
+++ b/ios/Runner/LiveActivityAttributes.swift
@@ -1,0 +1,44 @@
+import ActivityKit
+import Foundation
+
+// MARK: - Stunden Live Activity
+
+enum ActivityPhase: String, Codable {
+    case lesson
+    case `break`
+    case dayEnd
+}
+
+@available(iOS 16.2, *)
+struct LessonActivityAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+        var phase: ActivityPhase
+        var phaseStartTime: Date   // start of current phase (for progress bar)
+        var phaseEndTime: Date     // end of current phase (countdown target)
+        var nextLessonName: String?
+        var nextLessonRoom: String?
+        var nextLessonTeacher: String?
+        var nextLessonStart: String?  // "HH:mm" display string
+    }
+
+    var lessonName: String
+    var teacher: String?
+    var room: String?
+}
+
+// MARK: - Vertretungs Live Activity
+struct LiveSubstitutionEntry: Codable, Hashable {
+    let stunde: String
+    let fach: String?
+    let art: String?
+}
+
+@available(iOS 16.2, *)
+struct SubstitutionActivityAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+        var entries: [LiveSubstitutionEntry]
+        var count: Int
+    }
+
+    var date: String
+}

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.io.github.alessioc42.sph.widgets</string>
+	</array>
+</dict>
+</plist>

--- a/ios/Runner/SubstitutionActivityManager.swift
+++ b/ios/Runner/SubstitutionActivityManager.swift
@@ -1,0 +1,64 @@
+import ActivityKit
+import Flutter
+import Foundation
+
+@available(iOS 16.2, *)
+struct SubstitutionActivityJson: Decodable {
+    let date: String
+    let newEntries: [LiveSubstitutionEntry]
+}
+
+@available(iOS 16.2, *)
+enum SubstitutionActivityManager {
+    private static var currentActivity: Activity<SubstitutionActivityAttributes>?
+
+    static func start(json: String, result: @escaping FlutterResult) {
+        guard let data = json.data(using: .utf8),
+              let payload = try? JSONDecoder().decode(SubstitutionActivityJson.self, from: data)
+        else {
+            result(FlutterError(code: "PARSE_ERROR", message: "Could not parse substitution json", details: nil))
+            return
+        }
+
+        let attrs = SubstitutionActivityAttributes(date: payload.date)
+        let state = SubstitutionActivityAttributes.ContentState(
+            entries: payload.newEntries,
+            count: payload.newEntries.count
+        )
+
+        Task {
+            if let existing = currentActivity ?? existingActivity() {
+                await existing.end(dismissalPolicy: .immediate)
+                currentActivity = nil
+            }
+            do {
+                currentActivity = try Activity.request(
+                    attributes: attrs,
+                    contentState: state,
+                    pushType: nil
+                )
+                DispatchQueue.main.async { result(nil) }
+            } catch {
+                DispatchQueue.main.async {
+                    result(FlutterError(code: "ACTIVITY_ERROR", message: error.localizedDescription, details: nil))
+                }
+            }
+        }
+    }
+
+    private static func existingActivity() -> Activity<SubstitutionActivityAttributes>? {
+        Activity<SubstitutionActivityAttributes>.activities.first
+    }
+
+    static func end(result: @escaping FlutterResult) {
+        guard let activity = currentActivity ?? existingActivity() else {
+            result(nil)
+            return
+        }
+        currentActivity = nil
+        Task {
+            await activity.end(dismissalPolicy: .immediate)
+            DispatchQueue.main.async { result(nil) }
+        }
+    }
+}

--- a/ios/Runner/WidgetChannel.swift
+++ b/ios/Runner/WidgetChannel.swift
@@ -1,0 +1,84 @@
+import Flutter
+import WidgetKit
+import ActivityKit
+
+class WidgetChannel {
+    static let channelName = "io.github.alessioc42.sph/widgets"
+    private static let defaults = UserDefaults(suiteName: "group.io.github.alessioc42.sph.widgets")
+
+    static func register(with controller: FlutterViewController) {
+        let channel = FlutterMethodChannel(name: channelName, binaryMessenger: controller.binaryMessenger)
+        channel.setMethodCallHandler { call, result in
+            switch call.method {
+            case "writeData":
+                guard let args = call.arguments as? [String: String],
+                      let key = args["key"], let value = args["value"] else {
+                    result(FlutterError(code: "INVALID_ARGS", message: nil, details: nil))
+                    return
+                }
+                defaults?.set(value, forKey: key)
+                result(nil)
+
+            case "reloadWidgets":
+                if #available(iOS 14.0, *) {
+                    WidgetCenter.shared.reloadAllTimelines()
+                }
+                result(nil)
+
+            case "startLessonActivity":
+                if #available(iOS 16.2, *) {
+                    guard let json = call.arguments as? String else {
+                        result(FlutterError(code: "INVALID_ARGS", message: nil, details: nil))
+                        return
+                    }
+                    LessonActivityManager.start(json: json, result: result)
+                } else {
+                    result(nil)
+                }
+
+            case "updateLessonActivity":
+                if #available(iOS 16.2, *) {
+                    guard let json = call.arguments as? String else {
+                        result(FlutterError(code: "INVALID_ARGS", message: nil, details: nil))
+                        return
+                    }
+                    LessonActivityManager.update(json: json, result: result)
+                } else {
+                    result(nil)
+                }
+
+            case "endLessonActivity":
+                if #available(iOS 16.2, *) {
+                    LessonActivityManager.end(result: result)
+                } else {
+                    result(nil)
+                }
+
+            case "startSubstitutionActivity":
+                if #available(iOS 16.2, *) {
+                    guard let json = call.arguments as? String else {
+                        result(FlutterError(code: "INVALID_ARGS", message: nil, details: nil))
+                        return
+                    }
+                    SubstitutionActivityManager.start(json: json, result: result)
+                } else {
+                    result(nil)
+                }
+
+            case "endSubstitutionActivity":
+                if #available(iOS 16.2, *) {
+                    SubstitutionActivityManager.end(result: result)
+                } else {
+                    result(nil)
+                }
+
+            case "getInitialWidget":
+                result(AppDelegate.pendingWidgetURL)
+                AppDelegate.pendingWidgetURL = nil
+
+            default:
+                result(FlutterMethodNotImplemented)
+            }
+        }
+    }
+}

--- a/lib/applets/timetable/student/student_timetable_better_view.dart
+++ b/lib/applets/timetable/student/student_timetable_better_view.dart
@@ -98,6 +98,7 @@ class _StudentTimetableBetterViewState
               currentWeekIndex == 0 ? null : uniqueBadges[currentWeekIndex - 1],
             );
 
+
             headerHeight =
                 timetable.weekBadge != null && timetable.weekBadge!.isNotEmpty
                 ? 40

--- a/lib/background_service.dart
+++ b/lib/background_service.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_background_executor/flutter_background_executor.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:lanis/core/connection_checker.dart';
+import 'package:lanis/core/widget_data_service.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:lanis/applets/definitions.dart';
 import 'package:lanis/models/account_types.dart';
@@ -138,49 +139,54 @@ Future<void> callbackDispatcher() async {
       final ClearTextAccount clearTextAccount =
           await AccountDatabase.getAccountFromTableData(account);
       final sph = SPH(account: clearTextAccount);
-      if (!await sph.prefs.kv.get('notifications-allow')) {
-        sph.prefs.close();
-        continue;
-      }
       accountBackgroundTasks.add(() async {
-        List<Future> appletTasks = [];
-        bool authenticated = false;
-        for (final applet in AppDefinitions.applets.where(
-          (a) => a.notificationTask != null,
-        )) {
-          if (applet.supportedAccountTypes.contains(
-                clearTextAccount.accountType,
-              ) &&
-              (await sph.prefs.kv.get('notification-${applet.appletPhpUrl}') ??
-                  true)) {
-            if (!authenticated) {
-              await sph.session.prepareDio();
-              await sph.session.authenticate(withoutData: true);
-              authenticated = true;
-            }
-            if (!sph.session.doesSupportFeature(
-              applet,
-              overrideAccountType: clearTextAccount.accountType,
-            )) {
-              continue;
-            }
-            appletTasks.add(
-              applet.notificationTask!(
-                sph,
-                clearTextAccount.accountType ?? AccountType.student,
-                BackgroundTaskToolkit(
+        final accountType =
+            clearTextAccount.accountType ?? AccountType.student;
+        final notificationsAllowed =
+            await sph.prefs.kv.get('notifications-allow');
+
+        if (notificationsAllowed) {
+          List<Future> appletTasks = [];
+          bool authenticated = false;
+          for (final applet in AppDefinitions.applets.where(
+            (a) => a.notificationTask != null,
+          )) {
+            if (applet.supportedAccountTypes.contains(
+                  clearTextAccount.accountType,
+                ) &&
+                (await sph.prefs.kv.get('notification-${applet.appletPhpUrl}') ??
+                    true)) {
+              if (!authenticated) {
+                await sph.session.prepareDio();
+                await sph.session.authenticate(withoutData: true);
+                authenticated = true;
+              }
+              if (!sph.session.doesSupportFeature(
+                applet,
+                overrideAccountType: clearTextAccount.accountType,
+              )) {
+                continue;
+              }
+              appletTasks.add(
+                applet.notificationTask!(
                   sph,
-                  applet.appletPhpUrl,
-                  multiAccount: accounts.length > 1,
+                  clearTextAccount.accountType ?? AccountType.student,
+                  BackgroundTaskToolkit(
+                    sph,
+                    applet.appletPhpUrl,
+                    multiAccount: accounts.length > 1,
+                  ),
                 ),
-              ),
-            );
+              );
+            }
+          }
+          await Future.wait(appletTasks);
+          if (authenticated) {
+            await sph.session.deAuthenticate();
           }
         }
-        await Future.wait(appletTasks);
-        if (authenticated) {
-          await sph.session.deAuthenticate();
-        }
+
+        await WidgetDataService.instance.updateAll(sph, accountType);
         sph.prefs.close();
       }());
     }
@@ -280,21 +286,26 @@ class BackgroundTaskToolkit {
 Future<bool> isTaskWithinConstraints(AccountDatabase accountDB) async {
   final globalSettings = await accountDB.kv.getMultiple([
     'notifications-allowed-days',
-    'notifications-start-time',
-    'notifications-end-time',
+    'notifications-time-periods',
   ]);
-  TimeOfDay currentTime = TimeOfDay.now();
-  TimeOfDay startTime = TimeOfDay(
-    hour: globalSettings['notifications-start-time'][0],
-    minute: globalSettings['notifications-start-time'][1],
-  );
-  TimeOfDay endTime = TimeOfDay(
-    hour: globalSettings['notifications-end-time'][0],
-    minute: globalSettings['notifications-end-time'][1],
-  );
-  if (currentTime.hour < startTime.hour || currentTime.hour > endTime.hour) {
+
+  final int currentDayIndex = DateTime.now().weekday - 1;
+  if (!(globalSettings['notifications-allowed-days'][currentDayIndex] as bool)) {
     return false;
   }
-  int currentDayIndex = DateTime.now().weekday - 1;
-  return globalSettings['notifications-allowed-days'][currentDayIndex];
+
+  final now = TimeOfDay.now();
+  final int nowMinutes = now.hour * 60 + now.minute;
+
+  final List<dynamic> periods = globalSettings['notifications-time-periods'];
+  return periods.any((period) {
+    final int start = (period[0] as int) * 60 + (period[1] as int);
+    final int end = (period[2] as int) * 60 + (period[3] as int);
+    if (end >= start) {
+      return nowMinutes >= start && nowMinutes <= end;
+    } else {
+      // Midnight-spanning period (e.g. 23:00–01:00)
+      return nowMinutes >= start || nowMinutes <= end;
+    }
+  });
 }

--- a/lib/core/database/account_database/kv_defaults.dart
+++ b/lib/core/database/account_database/kv_defaults.dart
@@ -5,6 +5,9 @@ final Map<String, dynamic> kvDefaults = {
   "notifications-allowed-days": [true, true, true, true, true, false, false],
   "notifications-start-time": Platform.isIOS ? [5, 30] : [6, 30],
   "notifications-end-time": Platform.isIOS ? [16, 30] : [15, 0],
+  "notifications-time-periods": Platform.isIOS
+      ? [[5, 30, 16, 30]]
+      : [[6, 30, 15, 0]],
   "last-app-version": "0.0.0",
   "color": "standard",
   "theme": "system",

--- a/lib/core/demo/demo_calendar_parser.dart
+++ b/lib/core/demo/demo_calendar_parser.dart
@@ -1,0 +1,80 @@
+import 'package:lanis/applets/calendar/parser.dart';
+import 'package:lanis/core/demo/demo_fetch_mixin.dart';
+import 'package:lanis/models/calendar_event.dart';
+
+class DemoCalendarParser extends CalendarParser with DemoFetchMixin<List<CalendarEvent>> {
+  DemoCalendarParser(super.sph, super.appletDefinition);
+
+  @override
+  Future<List<CalendarEvent>> getHome() async {
+    final now = DateTime.now();
+    final monday = now.subtract(Duration(days: now.weekday - 1));
+
+    return [
+      CalendarEvent(
+        id: 'demo-1',
+        title: 'Klassenfahrt Planung',
+        description: 'Besprechung der Klassenfahrt nach Berlin',
+        startTime: monday.add(const Duration(hours: 8)),
+        endTime: monday.add(const Duration(hours: 9)),
+        allDay: false,
+        secret: false,
+        isNew: false,
+        public: true,
+        private: false,
+        place: 'Aula',
+      ),
+      CalendarEvent(
+        id: 'demo-2',
+        title: 'Elternsprechtag',
+        description: 'Halbjährlicher Elternsprechtag',
+        startTime: monday.add(const Duration(days: 1, hours: 14)),
+        endTime: monday.add(const Duration(days: 1, hours: 18)),
+        allDay: false,
+        secret: false,
+        isNew: true,
+        public: true,
+        private: false,
+        place: 'Schulgebäude',
+      ),
+      CalendarEvent(
+        id: 'demo-3',
+        title: 'Sportfest',
+        description: 'Jährliches Schulsportfest auf dem Sportplatz',
+        startTime: monday.add(const Duration(days: 2)),
+        endTime: monday.add(const Duration(days: 2, hours: 23, minutes: 59)),
+        allDay: true,
+        secret: false,
+        isNew: false,
+        public: true,
+        private: false,
+        place: 'Sportplatz',
+      ),
+      CalendarEvent(
+        id: 'demo-4',
+        title: 'Schulfeier 50 Jahre',
+        description: 'Festakt zum Schuljubiläum',
+        startTime: monday.add(const Duration(days: 3, hours: 16)),
+        endTime: monday.add(const Duration(days: 3, hours: 19)),
+        allDay: false,
+        secret: false,
+        isNew: false,
+        public: true,
+        private: false,
+        place: 'Aula',
+      ),
+      CalendarEvent(
+        id: 'demo-5',
+        title: 'Hausaufgaben Mathe',
+        description: 'Seite 42–44 im Buch',
+        startTime: monday.add(const Duration(days: 4)),
+        endTime: monday.add(const Duration(days: 4)),
+        allDay: true,
+        secret: false,
+        isNew: false,
+        public: false,
+        private: true,
+      ),
+    ];
+  }
+}

--- a/lib/core/demo/demo_conversations_parser.dart
+++ b/lib/core/demo/demo_conversations_parser.dart
@@ -1,0 +1,31 @@
+import 'package:lanis/applets/conversations/parser.dart';
+import 'package:lanis/core/demo/demo_fetch_mixin.dart';
+import 'package:lanis/models/conversations.dart';
+
+class DemoConversationsParser extends ConversationsParser with DemoFetchMixin<List<OverviewEntry>> {
+  DemoConversationsParser(super.sph, super.appletDefinition);
+
+  @override
+  Future<List<OverviewEntry>> getHome() async {
+    return const [
+      OverviewEntry(
+        id: 'demo-conv-1',
+        title: 'Klassenfahrt: Wichtige Infos',
+        shortName: 'BRA',
+        fullName: 'Herr Brandt',
+        date: '03.06.2026',
+        unread: true,
+        hidden: false,
+      ),
+      OverviewEntry(
+        id: 'demo-conv-2',
+        title: 'Informationen zum Schuljahresabschluss',
+        shortName: 'SL',
+        fullName: 'Schulleitung',
+        date: '01.06.2026',
+        unread: false,
+        hidden: false,
+      ),
+    ];
+  }
+}

--- a/lib/core/demo/demo_data_storage_parser.dart
+++ b/lib/core/demo/demo_data_storage_parser.dart
@@ -1,0 +1,32 @@
+import 'package:lanis/applets/data_storage/parser.dart';
+import 'package:lanis/core/demo/demo_fetch_mixin.dart';
+import 'package:lanis/models/datastorage.dart';
+
+class DemoDataStorageParser extends DataStorageParser with DemoFetchMixin<(List<FileNode>, List<FolderNode>)> {
+  DemoDataStorageParser(super.sph, super.appletDefinition);
+
+  @override
+  Future<(List<FileNode>, List<FolderNode>)> getHome() async {
+    final folder = FolderNode('Klassenarbeiten', 1, 0, 'Alle Klassenarbeiten des Schuljahres');
+    final files = [
+      FileNode(
+        name: 'KA_Mathematik_2026-04.pdf',
+        id: 101,
+        folderID: 1,
+        downloadUrl: '',
+        groesse: '245 KB',
+        aenderung: '15.04.2026',
+        hinweis: 'Klassenarbeit mit Lösungen',
+      ),
+      FileNode(
+        name: 'KA_Deutsch_2026-03.pdf',
+        id: 102,
+        folderID: 1,
+        downloadUrl: '',
+        groesse: '312 KB',
+        aenderung: '22.03.2026',
+      ),
+    ];
+    return (files, [folder]);
+  }
+}

--- a/lib/core/demo/demo_fetch_mixin.dart
+++ b/lib/core/demo/demo_fetch_mixin.dart
@@ -1,0 +1,30 @@
+import 'package:lanis/core/applet_parser.dart';
+
+mixin DemoFetchMixin<T> on AppletParser<T> {
+  @override
+  Future<void> fetchData({
+    bool forceRefresh = false,
+    bool secondTry = false,
+  }) async {
+    if (isEmpty || forceRefresh) {
+      addResponse(FetcherResponse(status: FetcherStatus.fetching, error: null));
+      try {
+        final data = await getHome();
+        addResponse(
+          FetcherResponse<T>(status: FetcherStatus.done, content: data, error: null),
+        );
+        isEmpty = false;
+      } catch (ex, stack) {
+        addResponse(
+          FetcherResponse<T>(
+            status: FetcherStatus.error,
+            error: ExceptionWithStackTrace(
+              exception: ex is Exception ? ex : Exception(ex.toString()),
+              stackTrace: stack,
+            ),
+          ),
+        );
+      }
+    }
+  }
+}

--- a/lib/core/demo/demo_lessons_student_parser.dart
+++ b/lib/core/demo/demo_lessons_student_parser.dart
@@ -1,0 +1,86 @@
+import 'package:lanis/applets/lessons/student/parser.dart';
+import 'package:lanis/core/demo/demo_fetch_mixin.dart';
+import 'package:lanis/models/lessons.dart';
+
+class DemoLessonsStudentParser extends LessonsStudentParser with DemoFetchMixin<Lessons> {
+  DemoLessonsStudentParser(super.sph, super.appletDefinition);
+
+  @override
+  Future<Lessons> getHome() async {
+    final now = DateTime.now();
+    return [
+      Lesson(
+        courseID: 'demo-ma',
+        name: 'Mathematik (10a)',
+        teachers: [LessonTeacher(teacher: 'Herr Müller', teacherKuerzel: 'MÜL')],
+        courseURL: Uri.parse('https://start.schulportal.hessen.de/meinunterricht.php?id=demo-ma'),
+        attendances: {'anwesend': '22', 'entschuldigt': '1', 'unentschuldigt': '0'},
+        currentEntry: CurrentEntry(
+          entryID: 'demo-ma-1',
+          topicTitle: 'Quadratische Gleichungen',
+          description: 'Lösungsverfahren: PQ-Formel und quadratische Ergänzung',
+          topicDate: now.subtract(const Duration(days: 1)),
+          schoolHours: '3',
+          presence: 'anwesend',
+          homework: Homework(description: 'Aufgaben S. 87 Nr. 3–6', homeWorkDone: false),
+          files: [],
+          uploads: [],
+        ),
+      ),
+      Lesson(
+        courseID: 'demo-de',
+        name: 'Deutsch (10a)',
+        teachers: [LessonTeacher(teacher: 'Frau Koch', teacherKuerzel: 'KOC')],
+        courseURL: Uri.parse('https://start.schulportal.hessen.de/meinunterricht.php?id=demo-de'),
+        attendances: {'anwesend': '23', 'entschuldigt': '0', 'unentschuldigt': '0'},
+        currentEntry: CurrentEntry(
+          entryID: 'demo-de-1',
+          topicTitle: 'Erörterung schreiben',
+          description: 'Aufbau und Argumentation einer Erörterung',
+          topicDate: now.subtract(const Duration(days: 2)),
+          schoolHours: '1',
+          presence: 'anwesend',
+          homework: Homework(description: 'Einleitung fertigschreiben', homeWorkDone: true),
+          files: [],
+          uploads: [],
+        ),
+      ),
+      Lesson(
+        courseID: 'demo-en',
+        name: 'Englisch (10a)',
+        teachers: [LessonTeacher(teacher: 'Frau Weber', teacherKuerzel: 'WEB')],
+        courseURL: Uri.parse('https://start.schulportal.hessen.de/meinunterricht.php?id=demo-en'),
+        attendances: {'anwesend': '21', 'entschuldigt': '2', 'unentschuldigt': '0'},
+        currentEntry: CurrentEntry(
+          entryID: 'demo-en-1',
+          topicTitle: 'Present Perfect vs. Simple Past',
+          description: 'Unterschiede und Anwendungsbeispiele',
+          topicDate: now,
+          schoolHours: '5',
+          presence: 'anwesend',
+          homework: null,
+          files: [],
+          uploads: [],
+        ),
+      ),
+      Lesson(
+        courseID: 'demo-bi',
+        name: 'Biologie (10a)',
+        teachers: [LessonTeacher(teacher: 'Herr Fischer', teacherKuerzel: 'FIS')],
+        courseURL: Uri.parse('https://start.schulportal.hessen.de/meinunterricht.php?id=demo-bi'),
+        attendances: {'anwesend': '23', 'entschuldigt': '0', 'unentschuldigt': '0'},
+        currentEntry: CurrentEntry(
+          entryID: 'demo-bi-1',
+          topicTitle: 'Zellteilung: Mitose',
+          description: 'Phasen der Mitose und ihre Bedeutung',
+          topicDate: now.subtract(const Duration(days: 3)),
+          schoolHours: '4',
+          presence: 'anwesend',
+          homework: Homework(description: 'Lernzettel zu den Mitose-Phasen', homeWorkDone: false),
+          files: [],
+          uploads: [],
+        ),
+      ),
+    ];
+  }
+}

--- a/lib/core/demo/demo_parsers.dart
+++ b/lib/core/demo/demo_parsers.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/foundation.dart';
+import 'package:lanis/applets/calendar/definition.dart';
+import 'package:lanis/applets/conversations/definition.dart';
+import 'package:lanis/applets/data_storage/definition.dart';
+import 'package:lanis/applets/lessons/definition.dart';
+import 'package:lanis/applets/study_groups/definitions.dart';
+import 'package:lanis/applets/substitutions/definition.dart';
+import 'package:lanis/applets/timetable/definition.dart';
+import 'package:lanis/core/demo/demo_calendar_parser.dart';
+import 'package:lanis/core/demo/demo_conversations_parser.dart';
+import 'package:lanis/core/demo/demo_data_storage_parser.dart';
+import 'package:lanis/core/demo/demo_lessons_student_parser.dart';
+import 'package:lanis/core/demo/demo_study_groups_parser.dart';
+import 'package:lanis/core/demo/demo_substitutions_parser.dart';
+import 'package:lanis/core/demo/demo_timetable_parser.dart';
+import 'package:lanis/core/sph/parsers.dart';
+import 'package:lanis/applets/calendar/parser.dart';
+import 'package:lanis/applets/conversations/parser.dart';
+import 'package:lanis/applets/data_storage/parser.dart';
+import 'package:lanis/applets/lessons/student/parser.dart';
+import 'package:lanis/applets/study_groups/student/parser.dart';
+import 'package:lanis/applets/substitutions/parser.dart';
+import 'package:lanis/applets/timetable/student/parser.dart';
+
+// Debug-only: all entry points are guarded by kDebugMode checks.
+class DemoParsers extends Parsers {
+  DemoParsers({required super.sph}) : assert(kDebugMode);
+
+  DemoSubstitutionsParser? _demoSubstitutionsParser;
+  DemoCalendarParser? _demoCalendarParser;
+  DemoTimetableStudentParser? _demoTimetableParser;
+  DemoLessonsStudentParser? _demoLessonsStudentParser;
+  DemoConversationsParser? _demoConversationsParser;
+  DemoDataStorageParser? _demoDataStorageParser;
+  DemoStudyGroupsStudentParser? _demoStudyGroupsParser;
+
+  @override
+  SubstitutionsParser get substitutionsParser =>
+      _demoSubstitutionsParser ??= DemoSubstitutionsParser(sph, substitutionDefinition);
+
+  @override
+  CalendarParser get calendarParser =>
+      _demoCalendarParser ??= DemoCalendarParser(sph, calendarDefinition);
+
+  @override
+  TimetableStudentParser get timetableStudentParser =>
+      _demoTimetableParser ??= DemoTimetableStudentParser(sph, timeTableDefinition);
+
+  @override
+  LessonsStudentParser get lessonsStudentParser =>
+      _demoLessonsStudentParser ??= DemoLessonsStudentParser(sph, lessonsDefinition);
+
+  @override
+  ConversationsParser get conversationsParser =>
+      _demoConversationsParser ??= DemoConversationsParser(sph, conversationsDefinition);
+
+  @override
+  DataStorageParser get dataStorageParser =>
+      _demoDataStorageParser ??= DemoDataStorageParser(sph, dataStorageDefinition);
+
+  @override
+  StudyGroupsStudentParser get studyGroupsStudentParser =>
+      _demoStudyGroupsParser ??= DemoStudyGroupsStudentParser(sph, studyGroupsDefinition);
+}

--- a/lib/core/demo/demo_study_groups_parser.dart
+++ b/lib/core/demo/demo_study_groups_parser.dart
@@ -1,0 +1,60 @@
+import 'package:lanis/applets/study_groups/student/parser.dart';
+import 'package:lanis/core/demo/demo_fetch_mixin.dart';
+import 'package:lanis/models/study_groups.dart';
+
+class DemoStudyGroupsStudentParser extends StudyGroupsStudentParser with DemoFetchMixin<StudentStudyGroups> {
+  DemoStudyGroupsStudentParser(super.sph, super.appletDefinition);
+
+  @override
+  Future<StudentStudyGroups> getHome() async {
+    final teacher1 = StudentStudyGroupTeacher(
+      krz: 'MÜL', firstName: 'Hans', lastName: 'Müller',
+      email: 'mueller@demo-schule.de',
+    );
+    final teacher2 = StudentStudyGroupTeacher(
+      krz: 'WEB', firstName: 'Anna', lastName: 'Weber',
+      email: 'weber@demo-schule.de',
+    );
+
+    final exam1 = StudentStudyGroupExam(
+      id: 'exam-1',
+      courseId: 'demo-ma-lk',
+      courseName: 'Mathematik LK',
+      date: DateTime.now().add(const Duration(days: 14)),
+      durationLabel: '180 Min.',
+      hoursOfDay: '1–4',
+      type: 'Klausur',
+    );
+    final exam2 = StudentStudyGroupExam(
+      id: 'exam-2',
+      courseId: 'demo-en-gk',
+      courseName: 'Englisch GK',
+      date: DateTime.now().add(const Duration(days: 21)),
+      durationLabel: '90 Min.',
+      hoursOfDay: '3–4',
+      type: 'Klausur',
+    );
+
+    return StudentStudyGroups(
+      groups: [
+        StudentStudyGroup(
+          id: 'demo-ma-lk',
+          semester: '2025/26 – 1. Halbjahr',
+          courseName: 'Mathematik Leistungskurs',
+          courseSysId: 'ma-lk-1',
+          teachers: [teacher1],
+          exams: [exam1],
+        ),
+        StudentStudyGroup(
+          id: 'demo-en-gk',
+          semester: '2025/26 – 1. Halbjahr',
+          courseName: 'Englisch Grundkurs',
+          courseSysId: 'en-gk-1',
+          teachers: [teacher2],
+          exams: [exam2],
+        ),
+      ],
+      exams: [exam1, exam2],
+    );
+  }
+}

--- a/lib/core/demo/demo_substitutions_parser.dart
+++ b/lib/core/demo/demo_substitutions_parser.dart
@@ -1,0 +1,56 @@
+import 'package:lanis/applets/substitutions/parser.dart';
+import 'package:lanis/core/demo/demo_fetch_mixin.dart';
+import 'package:lanis/models/substitution.dart';
+import 'package:intl/intl.dart';
+
+class DemoSubstitutionsParser extends SubstitutionsParser with DemoFetchMixin<SubstitutionPlan> {
+  DemoSubstitutionsParser(super.sph, super.appletDefinition);
+
+  @override
+  Future<SubstitutionPlan> getHome() async {
+    final today = DateTime.now();
+    final fmt = DateFormat('dd.MM.yyyy');
+    final fmtEn = DateFormat('yyyy-MM-dd');
+    final todayStr = fmt.format(today);
+    final todayEnStr = fmtEn.format(today);
+
+    final plan = SubstitutionPlan(lastUpdated: today);
+    plan.add(SubstitutionDay(
+      parsedDate: todayStr,
+      substitutions: [
+        Substitution(
+          tag: todayStr,
+          tag_en: todayEnStr,
+          stunde: '3',
+          lehrer: 'Müller',
+          vertreter: 'Schmidt',
+          klasse: '10a',
+          fach: 'Mathematik',
+          raum: '204',
+          art: 'Vertretung',
+          Lehrerkuerzel: 'MÜL',
+          Vertreterkuerzel: 'SCH',
+          lerngruppe: null,
+          hervorgehoben: null,
+        ),
+        Substitution(
+          tag: todayStr,
+          tag_en: todayEnStr,
+          stunde: '5',
+          lehrer: 'Weber',
+          vertreter: null,
+          klasse: '10a',
+          fach: 'Englisch',
+          raum: null,
+          art: 'Ausfall',
+          hinweis: 'Selbststudium',
+          Lehrerkuerzel: 'WEB',
+          Vertreterkuerzel: null,
+          lerngruppe: null,
+          hervorgehoben: null,
+        ),
+      ],
+    ));
+    return plan;
+  }
+}

--- a/lib/core/demo/demo_timetable_parser.dart
+++ b/lib/core/demo/demo_timetable_parser.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:lanis/applets/timetable/student/parser.dart';
+import 'package:lanis/core/demo/demo_fetch_mixin.dart';
+import 'package:lanis/models/timetable.dart';
+
+class DemoTimetableStudentParser extends TimetableStudentParser with DemoFetchMixin<TimeTable> {
+  DemoTimetableStudentParser(super.sph, super.appletDefinition);
+
+  @override
+  Future<TimeTable> getHome() async {
+    final now = TimeOfDay.now();
+    // First lesson starts 1 minute from now so small/medium widgets always show content
+    final startMinutes = now.hour * 60 + now.minute + 1;
+
+    TimeOfDay offset(int addMinutes) {
+      final total = startMinutes + addMinutes;
+      return TimeOfDay(hour: (total ~/ 60) % 24, minute: total % 60);
+    }
+
+    final hours = [
+      TimeTableRow(TimeTableRowType.lesson, offset(0),   offset(45),  '1', 0),
+      TimeTableRow(TimeTableRowType.lesson, offset(50),  offset(95),  '2', 1),
+      TimeTableRow(TimeTableRowType.pause,  offset(95),  offset(115), 'Pause', 2),
+      TimeTableRow(TimeTableRowType.lesson, offset(115), offset(160), '3', 3),
+      TimeTableRow(TimeTableRowType.lesson, offset(165), offset(210), '4', 4),
+      TimeTableRow(TimeTableRowType.pause,  offset(210), offset(225), 'Pause', 5),
+      TimeTableRow(TimeTableRowType.lesson, offset(225), offset(270), '5', 6),
+      TimeTableRow(TimeTableRowType.lesson, offset(275), offset(320), '6', 7),
+    ];
+
+    TimetableSubject s(String id, String name, String raum, String lehrer, int stunde) =>
+        TimetableSubject(id: id, name: name, raum: raum, lehrer: lehrer,
+            badge: null, duration: 1,
+            startTime: () {
+              final row = hours.where((h) => h.lessonIndex == stunde && h.type == TimeTableRowType.lesson);
+              return row.isEmpty ? const TimeOfDay(hour: 8, minute: 0) : row.first.startTime;
+            }(),
+            endTime: () {
+              final row = hours.where((h) => h.lessonIndex == stunde && h.type == TimeTableRowType.lesson);
+              return row.isEmpty ? const TimeOfDay(hour: 8, minute: 45) : row.first.endTime;
+            }(),
+            stunde: stunde);
+
+    final planForOwn = [
+      [s('ma','Mathematik','204','Müller',0), s('de','Deutsch','101','Koch',1), s('en','Englisch','102','Weber',3), s('bi','Biologie','301','Fischer',4), s('sp','Sport','Sporthalle','Hoffmann',6), s('mu','Musik','103','Braun',7)],
+      [s('ge','Geschichte','105','Schulz',0), s('ma','Mathematik','204','Müller',1), s('de','Deutsch','101','Koch',3), s('ph','Physik','302','Zimmermann',4), s('en','Englisch','102','Weber',6), s('ku','Kunst','104','Becker',7)],
+      [s('bi','Biologie','301','Fischer',0), s('sp','Sport','Sporthalle','Hoffmann',1), s('ma','Mathematik','204','Müller',3), s('ge','Geschichte','105','Schulz',4), s('de','Deutsch','101','Koch',6), s('mu','Musik','103','Braun',7)],
+      [s('en','Englisch','102','Weber',0), s('ph','Physik','302','Zimmermann',1), s('bi','Biologie','301','Fischer',3), s('ma','Mathematik','204','Müller',4), s('ku','Kunst','104','Becker',6), s('ge','Geschichte','105','Schulz',7)],
+      [s('de','Deutsch','101','Koch',0), s('en','Englisch','102','Weber',1), s('sp','Sport','Sporthalle','Hoffmann',3), s('mu','Musik','103','Braun',4), s('ph','Physik','302','Zimmermann',6), s('ma','Mathematik','204','Müller',7)],
+    ];
+
+    return TimeTable(planForOwn: planForOwn, planForAll: null, hours: hours, weekBadge: null);
+  }
+}

--- a/lib/core/native_adapter_instance.dart
+++ b/lib/core/native_adapter_instance.dart
@@ -1,19 +1,65 @@
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
 import 'package:native_dio_adapter/native_dio_adapter.dart';
 
-NativeAdapter? _cachedNativeAdapter;
 CronetEngine? _cachedCronetEngine;
+HttpClientAdapter? _cachedAdapter;
 
-NativeAdapter getNativeAdapterInstance() {
-  if (_cachedNativeAdapter != null) return _cachedNativeAdapter!;
-  _cachedNativeAdapter = NativeAdapter(
-    createCronetEngine: () {
-      _cachedCronetEngine ??= CronetEngine.build(
-        enableHttp2: true,
-        enableBrotli: true,
-        enableQuic: true,
-      );
-      return _cachedCronetEngine!;
-    },
-  );
-  return _cachedNativeAdapter!;
+HttpClientAdapter getNativeAdapterInstance() {
+  _cachedAdapter ??= _FallbackAdapter();
+  return _cachedAdapter!;
+}
+
+class _FallbackAdapter implements HttpClientAdapter {
+  HttpClientAdapter? _native;
+  HttpClientAdapter? _fallback;
+  bool _useFallback = false;
+
+  HttpClientAdapter get _active {
+    if (_useFallback) return _fallback ??= HttpClientAdapter();
+    _native ??= NativeAdapter(
+      createCronetEngine: () {
+        _cachedCronetEngine ??= CronetEngine.build(
+          enableHttp2: true,
+          enableBrotli: true,
+          enableQuic: true,
+        );
+        return _cachedCronetEngine!;
+      },
+    );
+    return _native!;
+  }
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future? cancelFuture,
+  ) async {
+    try {
+      return await _active.fetch(options, requestStream, cancelFuture);
+    } catch (e) {
+      if (!_useFallback && _isNativeAdapterFailure(e)) {
+        _useFallback = true;
+        return await (_fallback ??= HttpClientAdapter())
+            .fetch(options, requestStream, cancelFuture);
+      }
+      rethrow;
+    }
+  }
+
+  static bool _isNativeAdapterFailure(Object e) {
+    final msg = e.toString();
+    return msg.contains('native_cupertino_bindings') ||
+        msg.contains('MissingPluginException') ||
+        msg.contains('CronetEngine') ||
+        (e is Error && e is! AssertionError);
+  }
+
+  @override
+  void close({bool force = false}) {
+    _native?.close(force: force);
+    _fallback?.close(force: force);
+  }
 }

--- a/lib/core/sph/session.dart
+++ b/lib/core/sph/session.dart
@@ -112,7 +112,7 @@ class SessionHandler {
     bool withoutData = false,
     String? withLoginUrl,
   }) async {
-    if (!(await connectionChecker.connected)) {
+    if (!(await connectionChecker.testConnection())) {
       throw NoConnectionException();
     }
 
@@ -366,5 +366,12 @@ class SessionHandler {
     return applet.supportedAccountTypes.contains(
       overrideAccountType ?? accountType,
     );
+  }
+
+  void setDemoAccountType(AccountType type) {
+    _accountType = type;
+    travelMenu = AppDefinitions.applets
+        .map((a) => {'link': a.appletPhpUrl})
+        .toList();
   }
 }

--- a/lib/core/widget_data_service.dart
+++ b/lib/core/widget_data_service.dart
@@ -1,0 +1,368 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'sph/sph.dart';
+import '../models/account_types.dart';
+import '../models/timetable.dart';
+import '../utils/logger.dart';
+
+class WidgetDataService {
+  WidgetDataService._();
+  static final instance = WidgetDataService._();
+
+  static const _channel = MethodChannel('io.github.alessioc42.sph/widgets');
+
+  bool _dayEndScheduled = false;
+
+  bool get _isIOS => Platform.isIOS;
+
+  Future<void> _write(String key, Map<String, dynamic> data) async {
+    if (!_isIOS) return;
+    try {
+      await _channel.invokeMethod('writeData', {
+        'key': key,
+        'value': jsonEncode(data),
+      });
+    } catch (e) {
+      logger.w('WidgetDataService: writeData failed for $key: $e');
+    }
+  }
+
+  Future<void> _reloadWidgets() async {
+    if (!_isIOS) return;
+    try {
+      await _channel.invokeMethod('reloadWidgets');
+    } catch (e) {
+      logger.w('WidgetDataService: reloadWidgets failed: $e');
+    }
+  }
+
+  Future<void> updateAll(SPH sph, AccountType accountType) async {
+    if (!_isIOS) return;
+    await Future.wait([
+      updateTimetable(sph),
+      updateSubstitutions(sph),
+      updateCalendar(sph),
+      updateConversations(sph),
+    ]);
+    await _reloadWidgets();
+  }
+
+  Future<void> updateTimetable(SPH sph) async {
+    if (!_isIOS) return;
+    try {
+      final data = await sph.parser.timetableStudentParser.getHome();
+      final now = TimeOfDay.now();
+      final today = _getTodayLessons(data);
+
+      TimetableSubject? current;
+      TimetableSubject? next;
+      String? phase;
+      String? phaseStartTime;
+      String? phaseEndTime;
+
+      for (int i = 0; i < today.length; i++) {
+        if (_isOngoing(today[i], now)) {
+          current = today[i];
+          next = (i + 1 < today.length) ? today[i + 1] : null;
+          phase = 'lesson';
+          phaseStartTime = _formatTime(today[i].startTime);
+          phaseEndTime = _formatTime(today[i].endTime);
+          break;
+        }
+        if (i + 1 < today.length && _isInBreak(today[i], today[i + 1], now)) {
+          current = today[i];
+          next = today[i + 1];
+          phase = 'break';
+          phaseStartTime = _formatTime(today[i].endTime);
+          phaseEndTime = _formatTime(today[i + 1].startTime);
+          break;
+        }
+      }
+
+      // Day end: after last lesson, before midnight
+      if (current == null && today.isNotEmpty) {
+        final lastLesson = today.last;
+        final lastEndMinutes =
+            lastLesson.endTime.hour * 60 + lastLesson.endTime.minute;
+        final nowMinutes = now.hour * 60 + now.minute;
+        if (nowMinutes >= lastEndMinutes) {
+          current = lastLesson;
+          phase = 'dayEnd';
+          phaseStartTime = _formatTime(lastLesson.endTime);
+          phaseEndTime = phaseStartTime; // dayEnd has no countdown
+        }
+      }
+
+      await _write('widget_timetable', {
+        'updatedAt': DateTime.now().toIso8601String(),
+        'today': today.map((l) => _lessonToJson(l)).toList(),
+        'currentLesson': current != null ? _lessonToJson(current) : null,
+      });
+
+      final liveActivityEnabled =
+          await sph.prefs.kv.get('live-activity-lesson') ?? true;
+      if (liveActivityEnabled == true && current != null && phase != null) {
+        if (phase == 'dayEnd') {
+          if (!_dayEndScheduled) {
+            _dayEndScheduled = true;
+            await updateLessonActivity(current, null,
+                phase: phase,
+                phaseStartTime: phaseStartTime!,
+                phaseEndTime: phaseEndTime!);
+            Future.delayed(const Duration(seconds: 50), () async {
+              await endLessonActivity();
+              _dayEndScheduled = false;
+            });
+          }
+        } else {
+          _dayEndScheduled = false;
+          await startLessonActivity(current, next,
+              phase: phase,
+              phaseStartTime: phaseStartTime!,
+              phaseEndTime: phaseEndTime!);
+        }
+      } else if (phase == null) {
+        _dayEndScheduled = false;
+        await endLessonActivity();
+      }
+    } catch (e) {
+      logger.w('WidgetDataService: updateTimetable failed: $e');
+    }
+  }
+
+  Future<void> updateSubstitutions(SPH sph) async {
+    if (!_isIOS) return;
+    try {
+      final plan = await sph.parser.substitutionsParser.getHome();
+      final today = plan.days.isNotEmpty ? plan.days.first : null;
+      final entries = today?.substitutions ?? [];
+
+      await _write('widget_substitutions', {
+        'updatedAt': DateTime.now().toIso8601String(),
+        'date': today?.parsedDate ?? '',
+        'entries': entries
+            .map((s) => {
+                  'stunde': s.stunde,
+                  'fach': s.fach,
+                  'art': s.art,
+                  'raum': s.raum,
+                  'vertreter': s.vertreter,
+                })
+            .toList(),
+      });
+    } catch (e) {
+      logger.w('WidgetDataService: updateSubstitutions failed: $e');
+    }
+  }
+
+  Future<void> updateCalendar(SPH sph) async {
+    if (!_isIOS) return;
+    try {
+      final events = await sph.parser.calendarParser.getHome();
+      final upcoming = events
+          .where((e) => e.endTime.isAfter(DateTime.now()))
+          .take(10)
+          .toList();
+
+      await _write('widget_calendar', {
+        'updatedAt': DateTime.now().toIso8601String(),
+        'events': upcoming
+            .map((e) => {
+                  'title': e.title,
+                  'start': e.startTime.toIso8601String(),
+                  'allDay': e.allDay,
+                  'color': _colorToHex(e.color),
+                })
+            .toList(),
+      });
+    } catch (e) {
+      logger.w('WidgetDataService: updateCalendar failed: $e');
+    }
+  }
+
+  Future<void> updateConversations(SPH sph) async {
+    if (!_isIOS) return;
+    try {
+      final entries = await sph.parser.conversationsParser.getHome();
+      final unread = entries.where((e) => e.unread).length;
+
+      await _write('widget_conversations', {
+        'updatedAt': DateTime.now().toIso8601String(),
+        'unreadCount': unread,
+        'latest': entries
+            .take(5)
+            .map((e) => {
+                  'sender': e.fullName,
+                  'subject': e.title,
+                  'isUnread': e.unread,
+                })
+            .toList(),
+      });
+    } catch (e) {
+      logger.w('WidgetDataService: updateConversations failed: $e');
+    }
+  }
+
+  Future<void> startLessonActivity(
+      TimetableSubject current,
+      TimetableSubject? next, {
+      required String phase,
+      required String phaseStartTime,
+      required String phaseEndTime,
+    }) async {
+    if (!_isIOS) return;
+    try {
+      await _channel.invokeMethod(
+          'startLessonActivity',
+          jsonEncode(_lessonActivityJson(current, next,
+              phase: phase,
+              phaseStartTime: phaseStartTime,
+              phaseEndTime: phaseEndTime)));
+    } catch (e) {
+      logger.w('WidgetDataService: startLessonActivity failed: $e');
+    }
+  }
+
+  Future<void> updateLessonActivity(
+      TimetableSubject current,
+      TimetableSubject? next, {
+      required String phase,
+      required String phaseStartTime,
+      required String phaseEndTime,
+    }) async {
+    if (!_isIOS) return;
+    try {
+      await _channel.invokeMethod(
+          'updateLessonActivity',
+          jsonEncode(_lessonActivityJson(current, next,
+              phase: phase,
+              phaseStartTime: phaseStartTime,
+              phaseEndTime: phaseEndTime)));
+    } catch (e) {
+      logger.w('WidgetDataService: updateLessonActivity failed: $e');
+    }
+  }
+
+  Future<void> endLessonActivity() async {
+    if (!_isIOS) return;
+    try {
+      await _channel.invokeMethod('endLessonActivity');
+    } catch (e) {
+      logger.w('WidgetDataService: endLessonActivity failed: $e');
+    }
+  }
+
+  Future<void> startSubstitutionActivity(
+      List<Map<String, String?>> entries) async {
+    if (!_isIOS) return;
+    try {
+      final json = jsonEncode({
+        'date': DateTime.now().toIso8601String(),
+        'newEntries': entries,
+      });
+      await _channel.invokeMethod('startSubstitutionActivity', json);
+    } catch (e) {
+      logger.w('WidgetDataService: startSubstitutionActivity failed: $e');
+    }
+  }
+
+  Future<void> endSubstitutionActivity() async {
+    if (!_isIOS) return;
+    try {
+      await _channel.invokeMethod('endSubstitutionActivity');
+    } catch (e) {
+      logger.w('WidgetDataService: endSubstitutionActivity failed: $e');
+    }
+  }
+
+  List<TimetableSubject> _getTodayLessons(TimeTable data) {
+    final today = data.planForOwn ?? data.planForAll ?? [];
+    final dayIndex = DateTime.now().weekday - 1; // 0=Mo
+    if (dayIndex < 0 || dayIndex >= today.length) return [];
+    return today[dayIndex];
+  }
+
+  bool _isOngoing(TimetableSubject lesson, TimeOfDay now) {
+    final startMinutes =
+        lesson.startTime.hour * 60 + lesson.startTime.minute;
+    final endMinutes = lesson.endTime.hour * 60 + lesson.endTime.minute;
+    final nowMinutes = now.hour * 60 + now.minute;
+    return nowMinutes >= startMinutes && nowMinutes < endMinutes;
+  }
+
+  bool _isInBreak(TimetableSubject prev, TimetableSubject next, TimeOfDay now) {
+    final prevEnd = prev.endTime.hour * 60 + prev.endTime.minute;
+    final nextStart = next.startTime.hour * 60 + next.startTime.minute;
+    final nowMinutes = now.hour * 60 + now.minute;
+    return nowMinutes >= prevEnd && nowMinutes < nextStart;
+  }
+
+  Map<String, dynamic> _lessonToJson(TimetableSubject l) => {
+        'name': l.name ?? '',
+        'room': l.raum,
+        'teacher': l.lehrer,
+        'start':
+            '${l.startTime.hour.toString().padLeft(2, '0')}:${l.startTime.minute.toString().padLeft(2, '0')}',
+        'end':
+            '${l.endTime.hour.toString().padLeft(2, '0')}:${l.endTime.minute.toString().padLeft(2, '0')}',
+        'stunde': l.stunde ?? 0,
+        'color': _colorForLesson(l),
+      };
+
+  /// Generates a deterministic color from the lesson name/id so each subject
+  /// always gets the same distinct color in the widget.
+  String _colorForLesson(TimetableSubject l) {
+    final key = (l.id?.split('-').first ?? l.name ?? '').toLowerCase();
+    final hash = key.codeUnits.fold(0, (h, c) => (h * 31 + c) & 0xFFFFFFFF);
+    const colors = [
+      '#E53935', // Rot
+      '#8E24AA', // Violett
+      '#1E88E5', // Blau
+      '#00897B', // Teal
+      '#43A047', // Grün
+      '#FB8C00', // Orange
+      '#F4511E', // Tiefes Orange
+      '#6D4C41', // Braun
+      '#00ACC1', // Cyan
+      '#3949AB', // Indigo
+    ];
+    return colors[hash % colors.length];
+  }
+
+  Map<String, dynamic> _lessonActivityJson(
+      TimetableSubject current, TimetableSubject? next, {
+      required String phase,
+      required String phaseStartTime,
+      required String phaseEndTime,
+    }) {
+    return {
+      'name': current.name ?? '',
+      'room': current.raum,
+      'teacher': current.lehrer,
+      'phase': phase,
+      'phaseStartTime': phaseStartTime,
+      'phaseEndTime': phaseEndTime,
+      'nextName': next?.name,
+      'nextRoom': next?.raum,
+      'nextTeacher': next?.lehrer,
+      'nextStart': next != null ? _formatTime(next.startTime) : null,
+    };
+  }
+
+  /// Converts a [Color] to a 6-digit RGB hex string (e.g. `#FF4242FC`).
+  /// Uses the new Flutter Color API (r/g/b as doubles 0.0–1.0) to avoid
+  /// the deprecated Color.value property.
+  String _colorToHex(Color color) {
+    final r = (color.r * 255).round().toRadixString(16).padLeft(2, '0');
+    final g = (color.g * 255).round().toRadixString(16).padLeft(2, '0');
+    final b = (color.b * 255).round().toRadixString(16).padLeft(2, '0');
+    return '#$r$g$b';
+  }
+
+  String _formatTime(TimeOfDay t) =>
+      '${t.hour.toString().padLeft(2, '0')}:${t.minute.toString().padLeft(2, '0')}';
+}

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -1,8 +1,12 @@
 import 'dart:ui';
+import 'dart:io';
+import 'package:flutter/services.dart';
 import 'package:lanis/core/database/account_database/account_db.dart';
 import 'package:lanis/core/sph/session.dart';
+import 'package:lanis/core/widget_data_service.dart';
 import 'package:lanis/models/account_types.dart';
 import 'package:lanis/models/client_status_exceptions.dart';
+import 'package:lanis/models/timetable.dart';
 import 'package:lanis/generated/l10n.dart';
 
 import 'package:flutter/material.dart';
@@ -86,6 +90,7 @@ class HomePage extends StatefulWidget {
 
 class HomePageState extends State<HomePage> {
   final GlobalKey<ScaffoldState> _drawerKey = GlobalKey();
+  static const _channel = MethodChannel('io.github.alessioc42.sph/widgets');
 
   bool doesSupportAnyApplet = true;
   List<Destination> destinations = [];
@@ -112,6 +117,90 @@ class HomePageState extends State<HomePage> {
     setDefaultDestination();
     super.initState();
     showUpdateInfoIfRequired(context);
+    _checkLiveActivityOnLaunch();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _handleInitialWidgetLink());
+  }
+
+  void _checkLiveActivityOnLaunch() {
+    if (!Platform.isIOS) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      if (!mounted) return;
+      final enabled = await sph?.prefs.kv.get('live-activity-lesson') ?? true;
+      if (enabled != true) return;
+
+      final timetableData = await _getCurrentLesson();
+      if (timetableData == null) return;
+      final (current, next) = timetableData;
+
+      if (!mounted) return;
+      // ignore: use_build_context_synchronously
+      final confirmed = await showDialog<bool>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          title: const Text('Live Activity starten?'),
+          content: Text(
+            '${current.name} läuft gerade. Soll die Live Activity auf dem Sperrbildschirm angezeigt werden?',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(false),
+              child: const Text('Nein'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(ctx).pop(true),
+              child: const Text('Ja'),
+            ),
+          ],
+        ),
+      );
+
+      if (confirmed == true) {
+        await WidgetDataService.instance.startLessonActivity(
+          current,
+          next,
+          phase: 'lesson',
+          phaseStartTime:
+              '${current.startTime.hour.toString().padLeft(2, '0')}:${current.startTime.minute.toString().padLeft(2, '0')}',
+          phaseEndTime:
+              '${current.endTime.hour.toString().padLeft(2, '0')}:${current.endTime.minute.toString().padLeft(2, '0')}',
+        );
+      }
+    });
+  }
+
+  Future<void> _handleInitialWidgetLink() async {
+    if (!Platform.isIOS) return;
+    try {
+      final url = await _channel.invokeMethod<String>('getInitialWidget');
+      if (url == null || !mounted) return;
+      final phpId = Uri.parse(url).pathSegments.last;
+      final idx = AppDefinitions.getIndexByPhpIdentifier(phpId);
+      if (idx < 0) return;
+      if (!destinations[idx].isSupported || !destinations[idx].enableBottomNavigation) return;
+      setState(() => selectedDestinationDrawer = idx);
+    } catch (_) {}
+  }
+
+  Future<(TimetableSubject, TimetableSubject?)?> _getCurrentLesson() async {
+    try {
+      final data = await sph!.parser.timetableStudentParser.getHome();
+      final now = TimeOfDay.now();
+      final weekday = DateTime.now().weekday - 1;
+      final plan = data.planForOwn ?? data.planForAll ?? [];
+      if (weekday < 0 || weekday >= plan.length) return null;
+      final today = plan[weekday];
+      for (int i = 0; i < today.length; i++) {
+        final l = today[i];
+        final start = l.startTime.hour * 60 + l.startTime.minute;
+        final end = l.endTime.hour * 60 + l.endTime.minute;
+        final nowMin = now.hour * 60 + now.minute;
+        if (nowMin >= start && nowMin < end) {
+          final next = i + 1 < today.length ? today[i + 1] : null;
+          return (l, next);
+        }
+      }
+    } catch (_) {}
+    return null;
   }
 
   @override

--- a/lib/models/substitution.dart
+++ b/lib/models/substitution.dart
@@ -72,10 +72,18 @@ class Substitution {
           filterElement(vertreter, filter["filter"], filter["strict"]),
       "Stunde": (filter) =>
           filterElement(stunde, filter["filter"], filter["strict"]),
-      "Lehrerkuerzel": (filter) =>
-          filterElement(Lehrerkuerzel, filter["filter"], filter["strict"]),
-      "Vertreterkuerzel": (filter) =>
-          filterElement(Vertreterkuerzel, filter["filter"], filter["strict"]),
+      "Lehrerkuerzel": (filter) => filterElement(
+        Lehrerkuerzel,
+        filter["filter"],
+        filter["strict"],
+        exactMatch: true,
+      ),
+      "Vertreterkuerzel": (filter) => filterElement(
+        Vertreterkuerzel,
+        filter["filter"],
+        filter["strict"],
+        exactMatch: true,
+      ),
       "Klasse_alt": (filter) =>
           filterElement(klasse_alt, filter["filter"], filter["strict"]),
       "Raum_alt": (filter) =>
@@ -99,17 +107,24 @@ class Substitution {
   }
 
   ///returns true if the value contains all of the filter elements
-  bool filterElement(String? value, List<String> filter, bool? strict) {
+  bool filterElement(
+    String? value,
+    List<String> filter,
+    bool? strict, {
+    bool exactMatch = false,
+  }) {
     if (value == null) {
       return false;
     }
     // remove all HTML tags from the value
     value = value.replaceAll(RegExp(r'<[^>]*>'), '');
+    bool matches(String filterEl) =>
+        exactMatch ? value! == filterEl : value!.contains(filterEl);
     if (!(strict ?? true)) {
-      return filter.any((element) => value!.contains(element));
+      return filter.any(matches);
     }
     for (var singleFilter in filter) {
-      if (!value.contains(singleFilter)) {
+      if (!matches(singleFilter)) {
         return false;
       }
     }

--- a/lib/utils/authentication_state.dart
+++ b/lib/utils/authentication_state.dart
@@ -1,5 +1,10 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:lanis/core/connection_checker.dart';
+import 'package:lanis/core/demo/demo_parsers.dart';
+import 'package:lanis/core/widget_data_service.dart';
 import 'package:lanis/home_page.dart';
+import 'package:lanis/models/account_types.dart';
 
 import '../core/database/account_database/account_db.dart';
 import '../core/sph/sph.dart';
@@ -43,6 +48,11 @@ class AuthenticationState {
 
       if (exception.value == null) {
         status.value = LoginStatus.done;
+        if (sph != null) {
+          WidgetDataService.instance
+              .updateAll(sph!, sph!.session.accountType)
+              .ignore();
+        }
       }
     } on (WrongCredentialsException, CredentialsIncompleteException) {
       status.value = LoginStatus.setup;
@@ -56,6 +66,33 @@ class AuthenticationState {
   void reset(final BuildContext context) {
     Phoenix.rebirth(context);
     login();
+  }
+
+  Future<void> loginDemo(AccountType accountType) async {
+    if (!kDebugMode) throw StateError('loginDemo must only be called in debug mode');
+    status.value = LoginStatus.waiting;
+    exception.value = null;
+    sph?.prefs.close();
+    sph = null;
+
+    sph = SPH(
+      account: ClearTextAccount(
+        localId: -1,
+        schoolID: 0,
+        username: 'demo',
+        password: '',
+        schoolName: 'Demo-Schule',
+        accountType: accountType,
+      ),
+    );
+
+    sph!.session.userData = {'vorname': 'Max', 'nachname': 'Mustermann'};
+    sph!.session.setDemoAccountType(accountType);
+    sph!.parser = DemoParsers(sph: sph!);
+    connectionChecker.status = ConnectionStatus.connected;
+
+    status.value = LoginStatus.done;
+    WidgetDataService.instance.updateAll(sph!, accountType).ignore();
   }
 }
 

--- a/lib/view/login/auth.dart
+++ b/lib/view/login/auth.dart
@@ -1,5 +1,7 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:lanis/models/account_types.dart';
 import 'package:lanis/core/database/account_database/account_db.dart';
 import 'package:lanis/core/sph/session.dart';
 import 'package:lanis/models/client_status_exceptions.dart';
@@ -102,6 +104,39 @@ class LoginFormState extends State<LoginForm> {
         );
       });
     }
+  }
+
+  void _showDemoDialog(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Demo starten'),
+        content: const Text('Wähle einen Account-Typ für die Demo-Session:'),
+        actions: [
+          TextButton(
+            onPressed: () {
+              Navigator.of(context).pop();
+              authenticationState.loginDemo(AccountType.student);
+            },
+            child: const Text('Schüler'),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.of(context).pop();
+              authenticationState.loginDemo(AccountType.teacher);
+            },
+            child: const Text('Lehrer'),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.of(context).pop();
+              authenticationState.loginDemo(AccountType.parent);
+            },
+            child: const Text('Elternteil'),
+          ),
+        ],
+      ),
+    );
   }
 
   @override
@@ -265,6 +300,14 @@ class LoginFormState extends State<LoginForm> {
                                 : null,
                             child: Text(AppLocalizations.of(context).logIn),
                           ),
+                          if (kDebugMode) ...[
+                            const SizedBox(height: padding),
+                            OutlinedButton.icon(
+                              icon: const Icon(Icons.bug_report_outlined),
+                              label: const Text('Demo starten'),
+                              onPressed: () => _showDemoDialog(context),
+                            ),
+                          ],
                           Row(
                             mainAxisAlignment: MainAxisAlignment.end,
                             children: [

--- a/lib/view/login/school_selector.dart
+++ b/lib/view/login/school_selector.dart
@@ -73,7 +73,8 @@ class _SchoolSelectorState extends State<SchoolSelector> {
       setState(() {
         schoolBezirke = result;
       });
-    } catch (e) {
+    } catch (e, st) {
+      debugPrint('[SchoolSelector] loadSchoolList error: $e\n$st');
       // Show a SnackBar to inform the user
       if (widget.outContext.mounted) {
         ScaffoldMessenger.of(widget.outContext).showSnackBar(

--- a/lib/view/moodle.dart
+++ b/lib/view/moodle.dart
@@ -53,6 +53,7 @@ class _MoodleWebViewState extends State<MoodleWebView> {
 
   bool showWebView = true;
   bool isLoggedIn = false;
+  bool _reAuthInProgress = false;
 
   InAppWebViewController? webViewController;
   PullToRefreshController? pullToRefreshController;
@@ -74,7 +75,63 @@ class _MoodleWebViewState extends State<MoodleWebView> {
     }
   }
 
-  Future<void> getCookies() async {
+  Future<void> _saveMoodleCookies(
+    dio_core.Cookie moProd01,
+    dio_core.Cookie moodleId1,
+    dio_core.Cookie moodleSession,
+    String moProd01Url,
+    String moodleUrl,
+  ) async {
+    final data = [
+      {
+        'name': moProd01.name,
+        'value': moProd01.value,
+        'domain': moProd01.domain ?? '',
+        'path': moProd01.path ?? '/',
+        'url': moProd01Url,
+      },
+      {
+        'name': moodleId1.name,
+        'value': moodleId1.value,
+        'domain': moodleId1.domain ?? '',
+        'path': moodleId1.path ?? '/',
+        'url': moodleUrl,
+      },
+      {
+        'name': moodleSession.name,
+        'value': moodleSession.value,
+        'domain': moodleSession.domain ?? '',
+        'path': moodleSession.path ?? '/',
+        'url': moodleUrl,
+      },
+    ];
+    await sph!.prefs.kv.set('moodle-cached-cookies', data);
+  }
+
+  Future<bool> _loadCachedMoodleCookies() async {
+    final cached = await sph!.prefs.kv.get('moodle-cached-cookies');
+    if (cached == null) return false;
+    try {
+      final List<dynamic> cookies = cached as List<dynamic>;
+      for (final c in cookies) {
+        await cookieManager.setCookie(
+          url: WebUri(c['url'] as String),
+          name: c['name'] as String,
+          value: c['value'] as String,
+          domain: c['domain'] as String,
+          path: c['path'] as String,
+          isHttpOnly: true,
+          isSecure: true,
+        );
+      }
+      return true;
+    } catch (_) {
+      await sph!.prefs.kv.set('moodle-cached-cookies', null);
+      return false;
+    }
+  }
+
+  Future<void> getCookies({bool forceFull = false}) async {
     if (!(await connectionChecker.connected)) {
       setState(() {
         isLoginError = true;
@@ -88,6 +145,21 @@ class _MoodleWebViewState extends State<MoodleWebView> {
       isLoginError = false;
       noInternetLogin = false;
     });
+
+    if (!forceFull) {
+      final restored = await _loadCachedMoodleCookies();
+      if (restored && webViewController != null) {
+        webViewController!.loadUrl(
+          urlRequest: URLRequest(
+            url: WebUri(
+              "https://mo${sph!.account.schoolID}.schulportal.hessen.de",
+            ),
+          ),
+        );
+        if (mounted) setState(() { isLoggedIn = true; });
+        return;
+      }
+    }
 
     try {
       final dio = Dio(BaseOptions(validateStatus: (status) => status != null));
@@ -178,6 +250,14 @@ class _MoodleWebViewState extends State<MoodleWebView> {
       addWebViewCookies(
         [moProd01Cookie, moodleId1Cookie, moodleSessionCookie],
         [location3, location4, location4],
+      );
+
+      await _saveMoodleCookies(
+        moProd01Cookie,
+        moodleId1Cookie,
+        moodleSessionCookie,
+        location3,
+        location4,
       );
 
       webViewController!.loadUrl(
@@ -352,7 +432,27 @@ class _MoodleWebViewState extends State<MoodleWebView> {
                   pullToRefreshController!.endRefreshing();
                   progressIndicator.value = 0;
 
-                  setState(() {}); // error
+                  // Detect Moodle session expiry: login page without a wantsurl param.
+                  if (url != null && !_reAuthInProgress) {
+                    final uri = Uri.tryParse(url.rawValue);
+                    if (uri != null &&
+                        uri.path.contains('/login/index.php') &&
+                        !uri.queryParameters.containsKey('wantsurl')) {
+                      // Session expired — clear cache and re-auth silently.
+                      _reAuthInProgress = true;
+                      await sph!.prefs.kv.set('moodle-cached-cookies', null);
+                      await cookieManager.deleteAllCookies();
+                      if (mounted) setState(() { isLoggedIn = false; });
+                      try {
+                        await getCookies(forceFull: true);
+                      } finally {
+                        _reAuthInProgress = false;
+                      }
+                      return;
+                    }
+                  }
+
+                  if (mounted) setState(() {}); // error
                 },
                 onTitleChanged: (controller, title) {
                   currentPageTitle.value = title ?? "";

--- a/lib/view/settings/settings.dart
+++ b/lib/view/settings/settings.dart
@@ -14,6 +14,7 @@ import 'package:lanis/view/settings/settings_page_builder.dart';
 import 'package:lanis/view/settings/subsettings/about.dart';
 import 'package:lanis/view/settings/subsettings/appearance.dart';
 import 'package:lanis/view/settings/subsettings/cache.dart';
+import 'package:lanis/view/settings/subsettings/live_activities.dart';
 import 'package:lanis/view/settings/subsettings/notifications.dart';
 import 'package:lanis/view/settings/subsettings/quick_actions.dart';
 import 'package:lanis/view/settings/subsettings/userdata.dart';
@@ -159,6 +160,16 @@ class _SettingsScreenState extends SettingsColoursState<SettingsScreen> {
               );
             }
           },
+        ),
+        SettingsTile(
+          title: (context) => 'Live Activities',
+          subtitle: (context) async => 'Aktuelle Stunde, Vertretungen',
+          icon: Icons.dynamic_feed_rounded,
+          show: () async => Platform.isIOS,
+          screen: (context) => Navigator.push(
+            context,
+            MaterialPageRoute(builder: (context) => const LiveActivitySettings()),
+          ),
         ),
         SettingsTile(
           title: (context) => AppLocalizations.of(context).clearCache,

--- a/lib/view/settings/subsettings/live_activities.dart
+++ b/lib/view/settings/subsettings/live_activities.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:lanis/core/sph/sph.dart';
+import 'package:lanis/view/settings/settings_page_builder.dart';
+
+class LiveActivitySettings extends SettingsColours {
+  const LiveActivitySettings({super.key});
+
+  @override
+  State<LiveActivitySettings> createState() => _LiveActivitySettingsState();
+}
+
+class _LiveActivitySettingsState
+    extends SettingsColoursState<LiveActivitySettings> {
+  static const _keyLesson = 'live-activity-lesson';
+
+  @override
+  Widget build(BuildContext context) {
+    return SettingsPageWithStreamBuilder(
+      backgroundColor: backgroundColor,
+      title: const Text('Live Activities'),
+      subscription: sph!.prefs.kv.subscribeMultiple([_keyLesson]),
+      builder: (context, snapshot) {
+        final lessonEnabled = (snapshot.data![_keyLesson] ?? true) == true;
+
+        return [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+            child: Text(
+              'Live Activities erscheinen auf dem Sperrbildschirm und in der Dynamic Island.',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Card.filled(
+              color: Theme.of(context).colorScheme.surfaceContainerHighest,
+              margin: EdgeInsets.zero,
+              clipBehavior: Clip.hardEdge,
+              child: InkWell(
+                onTap: () => sph!.prefs.kv.set(_keyLesson, !lessonEnabled),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 20,
+                    vertical: 12,
+                  ),
+                  child: Row(
+                    children: [
+                      const Icon(Icons.school_outlined, size: 20),
+                      const SizedBox(width: 16),
+                      const Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text('Aktuelle Stunde'),
+                            SizedBox(height: 2),
+                            Text(
+                              'Countdown und nächste Stunde im Unterricht',
+                              style: TextStyle(fontSize: 12),
+                            ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Switch(
+                        value: lessonEnabled,
+                        onChanged: (v) => sph!.prefs.kv.set(_keyLesson, v),
+                        padding: EdgeInsets.zero,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ];
+      },
+    );
+  }
+}

--- a/lib/view/settings/subsettings/notifications.dart
+++ b/lib/view/settings/subsettings/notifications.dart
@@ -16,7 +16,6 @@ import 'package:lanis/generated/l10n.dart';
 import '../../../core/sph/sph.dart';
 import '../../../utils/callout.dart';
 import '../../../utils/logger.dart';
-import '../../../utils/range_slider_tile.dart';
 import '../../../utils/slider_tile.dart';
 
 class NotificationSettings extends SettingsColours {
@@ -40,13 +39,10 @@ class _NotificationSettingsState
   double targetNotificationInterval =
       kvDefaults['notifications-target-interval-minutes'].toDouble();
   List<bool> enabledDays = kvDefaults['notifications-allowed-days'];
-  TimeOfDay startTime = TimeOfDay(
-    hour: kvDefaults['notifications-start-time'][0],
-    minute: kvDefaults['notifications-start-time'][1],
-  );
-  TimeOfDay endTime = TimeOfDay(
-    hour: kvDefaults['notifications-end-time'][0],
-    minute: kvDefaults['notifications-end-time'][1],
+  List<List<int>> timePeriods = List<List<int>>.from(
+    (kvDefaults['notifications-time-periods'] as List).map(
+      (p) => List<int>.from(p as List),
+    ),
   );
 
   PermissionStatus notificationPermissionStatus = PermissionStatus.provisional;
@@ -85,10 +81,30 @@ class _NotificationSettingsState
     final globalSettings = await accountDatabase.kv.getMultiple([
       'notifications-target-interval-minutes',
       'notifications-allowed-days',
+      'notifications-time-periods',
       'notifications-start-time',
       'notifications-end-time',
     ]);
 
+    // Migration: if new key missing, seed from old keys.
+    List<List<int>> periods;
+    final raw = globalSettings['notifications-time-periods'];
+    if (raw == null) {
+      final oldStart = globalSettings['notifications-start-time'] ??
+          kvDefaults['notifications-start-time'];
+      final oldEnd = globalSettings['notifications-end-time'] ??
+          kvDefaults['notifications-end-time'];
+      periods = [
+        [oldStart[0] as int, oldStart[1] as int, oldEnd[0] as int, oldEnd[1] as int],
+      ];
+      await accountDatabase.kv.set('notifications-time-periods', periods);
+    } else {
+      periods = List<List<int>>.from(
+        (raw as List).map((p) => List<int>.from(p as List)),
+      );
+    }
+
+    if (!mounted) return;
     setState(() {
       notificationPermissionStatus = notificationPermissionStatus;
       targetNotificationInterval =
@@ -96,14 +112,7 @@ class _NotificationSettingsState
       enabledDays = globalSettings['notifications-allowed-days']
           .map<bool>((e) => e as bool)
           .toList();
-      startTime = TimeOfDay(
-        hour: globalSettings['notifications-start-time'][0],
-        minute: globalSettings['notifications-start-time'][1],
-      );
-      endTime = TimeOfDay(
-        hour: globalSettings['notifications-end-time'][0],
-        minute: globalSettings['notifications-end-time'][1],
-      );
+      timePeriods = periods;
     });
   }
 
@@ -118,6 +127,55 @@ class _NotificationSettingsState
   void dispose() {
     checkTimer?.cancel();
     super.dispose();
+  }
+
+  String _formatPeriod(List<int> period) {
+    final start = TimeOfDay(hour: period[0], minute: period[1]);
+    final end = TimeOfDay(hour: period[2], minute: period[3]);
+    return '${start.format(context)} – ${end.format(context)}';
+  }
+
+  Future<void> _editPeriod(int index) async {
+    final existing = index < timePeriods.length ? timePeriods[index] : null;
+    final initialStart = existing != null
+        ? TimeOfDay(hour: existing[0], minute: existing[1])
+        : TimeOfDay(hour: 6, minute: 30);
+    final initialEnd = existing != null
+        ? TimeOfDay(hour: existing[2], minute: existing[3])
+        : TimeOfDay(hour: 15, minute: 0);
+
+    final start = await showTimePicker(
+      context: context,
+      initialTime: initialStart,
+      helpText: 'Startzeit',
+    );
+    if (start == null || !mounted) return;
+
+    final end = await showTimePicker(
+      context: context,
+      initialTime: initialEnd,
+      helpText: 'Endzeit',
+    );
+    if (end == null || !mounted) return;
+
+    final newPeriod = [start.hour, start.minute, end.hour, end.minute];
+    if (start.hour * 60 + start.minute == end.hour * 60 + end.minute) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Start- und Endzeit dürfen nicht gleich sein.')),
+        );
+      }
+      return;
+    }
+    final updated = List<List<int>>.from(timePeriods);
+    if (index < updated.length) {
+      updated[index] = newPeriod;
+    } else {
+      updated.add(newPeriod);
+    }
+
+    setState(() => timePeriods = updated);
+    await accountDatabase.kv.set('notifications-time-periods', updated);
   }
 
   @override
@@ -293,69 +351,61 @@ class _NotificationSettingsState
               SizedBox(width: 16.0),
             ],
           ),
-          Padding(
-            padding: const EdgeInsets.only(left: 16.0, top: 8.0),
-            child: RangeSliderTile(
-              title: Row(
+          ...timePeriods.asMap().entries.map((entry) {
+            final i = entry.key;
+            final period = entry.value;
+            return Padding(
+              padding: const EdgeInsets.only(left: 16.0, right: 8.0, bottom: 4.0),
+              child: Row(
                 children: [
-                  Text(
-                    AppLocalizations.of(context).timePeriod,
-                    style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                      color: activateBackgroundServices
-                          ? Theme.of(context).colorScheme.onSurface
-                          : Theme.of(context).colorScheme.onSurfaceVariant,
+                  Icon(
+                    Icons.schedule_outlined,
+                    color: activateBackgroundServices
+                        ? Theme.of(context).colorScheme.onSurface
+                        : Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+                  const SizedBox(width: 24.0),
+                  Expanded(
+                    child: Text(
+                      _formatPeriod(period),
+                      style: Theme.of(context).textTheme.bodyLarge!.copyWith(
+                        color: activateBackgroundServices
+                            ? Theme.of(context).colorScheme.onSurface
+                            : Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
                     ),
                   ),
-                  Spacer(),
-                  Text(
-                    "${startTime.format(context)} - ${endTime.format(context)}",
-                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: activateBackgroundServices
-                          ? Theme.of(context).colorScheme.onSurface
-                          : Theme.of(context).colorScheme.onSurfaceVariant,
-                    ),
+                  IconButton(
+                    icon: const Icon(Icons.edit_outlined),
+                    onPressed: activateBackgroundServices
+                        ? () => _editPeriod(i)
+                        : null,
                   ),
-                  SizedBox(width: 16.0),
+                  IconButton(
+                    icon: const Icon(Icons.delete_outline),
+                    onPressed: activateBackgroundServices && timePeriods.length > 1
+                        ? () async {
+                            final updated = List<List<int>>.from(timePeriods)..removeAt(i);
+                            setState(() => timePeriods = updated);
+                            await accountDatabase.kv.set(
+                              'notifications-time-periods',
+                              updated,
+                            );
+                          }
+                        : null,
+                  ),
                 ],
               ),
-              leading: Icon(
-                Icons.schedule_outlined,
-                color: activateBackgroundServices
-                    ? Theme.of(context).colorScheme.onSurface
-                    : Theme.of(context).colorScheme.onSurfaceVariant,
-              ),
-              values: RangeValues(
-                minutesSinceZero(startTime).toDouble(),
-                minutesSinceZero(endTime).toDouble(),
-              ),
-              max: 24 * 60,
-              min: 0,
-              divisions: 48,
-              labels: RangeLabels(
-                startTime.format(context),
-                endTime.format(context),
-              ),
-              onChanged: activateBackgroundServices
-                  ? (newValues) {
-                      setState(() {
-                        startTime = timeFromMinutesSinceZero(
-                          newValues.start.round(),
-                        );
-                        endTime = timeFromMinutesSinceZero(
-                          newValues.end.round(),
-                        );
-                      });
-                    }
+            );
+          }),
+          Padding(
+            padding: const EdgeInsets.only(left: 16.0, right: 16.0, bottom: 8.0),
+            child: TextButton.icon(
+              icon: const Icon(Icons.add),
+              label: const Text('Zeitraum hinzufügen'),
+              onPressed: activateBackgroundServices
+                  ? () => _editPeriod(timePeriods.length)
                   : null,
-              onChangeEnd: (newValues) {
-                accountDatabase.kv.setMultiple({
-                  'notifications-start-time': [
-                    startTime.hour,
-                    startTime.minute,
-                  ],
-                  'notifications-end-time': [endTime.hour, endTime.minute],
-                });
-              },
             ),
           ),
           Padding(

--- a/lib/widgets/format_text.dart
+++ b/lib/widgets/format_text.dart
@@ -2,6 +2,32 @@ import 'package:flutter/material.dart';
 import 'package:linkify/linkify.dart';
 import 'package:styled_text/styled_text.dart';
 import '../utils/url_modal.dart';
+import '../applets/definitions.dart';
+import '../core/sph/sph.dart';
+
+/// Navigates in-app to the matching applet if [uri] is a known SPH URL.
+/// Returns true if navigation was handled, false if the caller should fall back.
+bool navigateToSphUrl(BuildContext context, Uri uri) {
+  if (uri.host.toLowerCase() != 'start.schulportal.hessen.de') return false;
+
+  final phpFile = uri.pathSegments.isNotEmpty ? uri.pathSegments.last : '';
+  if (phpFile.isEmpty) return false;
+
+  final applet = AppDefinitions.applets
+      .where((a) => a.appletPhpUrl == phpFile)
+      .firstOrNull;
+  if (applet == null) return false;
+  if (applet.bodyBuilder == null) return false;
+  if (!sph!.session.doesSupportFeature(applet)) return false;
+
+  Navigator.of(context).push(
+    MaterialPageRoute(
+      builder: (ctx) =>
+          applet.bodyBuilder!(ctx, sph!.session.accountType, () {}),
+    ),
+  );
+  return true;
+}
 
 class FormatPattern {
   late final RegExp regExp;
@@ -356,7 +382,11 @@ class FormattedText extends StatelessWidget {
               padding: const EdgeInsets.only(top: 2, bottom: 2),
               child: InkWell(
                 onTap: () async {
-                  await openUrlModal(context, Uri.parse(attributes["href"]!));
+                  final uri = Uri.tryParse(attributes["href"]!);
+                  if (uri == null) return;
+                  if (!navigateToSphUrl(context, uri)) {
+                    await openUrlModal(context, uri);
+                  }
                 },
                 borderRadius: BorderRadius.circular(6),
                 child: Container(


### PR DESCRIPTION
Replaces #509 — same feature scope, cleanly based on `main` with Flutter-only changes extracted into #511 and #512.

## Summary

**iOS Widgets (4 widgets, 3 sizes + lock screen each)**
- `StundenplanWidget` — today's timetable with colored lesson blocks, progress overlay for ongoing lesson, and accessory (lock screen) families
- `VertretungsWidget` — substitution plan with small/medium/large views and lock screen families
- `KalenderWidget` — upcoming calendar events with a mini month grid (large size), Apple Calendar-style layout
- `NachrichtenWidget` — unread message count and latest conversations

**Live Activities (Dynamic Island + Lock Screen)**
- `StundenLiveActivityWidget` — lesson countdown with phase-aware views: lesson, break, day-end
- `SubstitutionActivityWidget` — real-time substitution list
- Started, updated, and ended from Flutter via `WidgetChannel` method channel

**Deep Links (`lanis://` URL scheme)**
- Widget taps open directly into the corresponding applet (timetable, substitutions, calendar, messages)
- `getInitialWidget` channel method lets Flutter read the pending URL on launch

**Flutter side**
- `WidgetDataService` — writes serialised JSON to shared App Group UserDefaults on every relevant data change
- Demo mode — static fake parsers for all applets so widgets are always populated without a school login
- Live Activities settings toggle page
- Notification time periods: multiple windows instead of a single start/end pair
- Moodle re-auth guard and cookie storage refactor
- Native HTTP adapter with Cronet fallback to standard Dart adapter
- Substitution filter: exact match for teacher abbreviations

## Related PRs

- #511 — Calendar category filter chips (extracted from #509)
- #512 — Lesson sort options + attendance table view (extracted from #509)

## Test plan

- [ ] Build on iOS device / simulator — widgets appear in widget gallery
- [ ] All 4 widgets render correctly in all supported sizes
- [ ] Live Activity starts when a lesson begins, updates on phase change, ends at day end
- [ ] Tapping a widget opens the correct applet via deep link
- [ ] Demo mode populates widgets without a school login
- [ ] Android release build unaffected