### PR TITLE
Add v3 legacy storage cleanup and restore lanis-logger login telemetry

### DIFF
--- a/lib/applets/lessons/student/course_overview.dart
+++ b/lib/applets/lessons/student/course_overview.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:liblanis/liblanis.dart';
 import 'package:intl/intl.dart';
+import 'package:lanis/bridge/login_telemetry.dart';
 import 'package:lanis/generated/l10n.dart';
 
 import '../../../utils/file_operations.dart' as fo;
@@ -62,7 +63,9 @@ class _CourseOverviewAnsichtState extends ConsumerState<CourseOverviewAnsicht> {
   Future<void> _loadData({bool secondTry = false, bool force = false}) async {
     try {
       if (secondTry) {
-        await ref.read(sessionProvider.notifier).authenticate();
+        await authenticateWithLoginTelemetry(
+          ref.read(sessionProvider.notifier),
+        );
       }
 
       String url = widget.dataFetchURL;

--- a/lib/background_service.dart
+++ b/lib/background_service.dart
@@ -11,6 +11,7 @@ import 'package:liblanis/liblanis.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:lanis/applets/definitions.dart';
 import 'package:lanis/bridge/lanis_bootstrap.dart';
+import 'package:lanis/bridge/legacy_storage_cleanup.dart';
 import 'package:lanis/l10n/account_type_ui.dart';
 import 'package:lanis/utils/logger.dart';
 import 'package:lanis/utils/privacy_policy.dart';
@@ -22,6 +23,7 @@ Future<void> setupBackgroundService() async {
     return;
   }
 
+  await removeLegacyV3StorageArtifacts();
   final overrides = await bootstrapLanisClient();
   final container = ProviderContainer(overrides: overrides);
   try {
@@ -120,6 +122,7 @@ Future<void> callbackDispatcher() async {
     backgroundLogger.i('Background fetch triggered');
     await initializeNotifications();
 
+    await removeLegacyV3StorageArtifacts();
     final overrides = await bootstrapLanisClient();
     final container = ProviderContainer(overrides: overrides);
     try {

--- a/lib/bridge/legacy_storage_cleanup.dart
+++ b/lib/bridge/legacy_storage_cleanup.dart
@@ -1,0 +1,101 @@
+import 'dart:io';
+
+import 'package:liblanis/liblanis.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import '../utils/logger.dart';
+import 'flutter_secret_store.dart';
+
+/// Secure-storage key used by the pre-v4 Drift stack for AES password wrapping.
+const legacyV3EncryptionKeyName = 'encryption_key';
+
+final _sessionDbName = RegExp(r'^session_\d+_db');
+final _numericDirName = RegExp(r'^\d+$');
+
+/// Whether [fileName] is a leftover v3 Drift SQLite file (including sidecars).
+bool isLegacyV3SqliteFileName(String fileName) {
+  if (fileName.startsWith('accounts_database')) return true;
+  return _sessionDbName.hasMatch(fileName);
+}
+
+/// Removes orphaned v3 Drift DBs, old document-cache trees, and `encryption_key`.
+///
+/// Leaves v4 `lanis.db`, `account_password_*`, and `lanis_documents/` untouched.
+/// Safe to call on every startup; a no-op once artifacts are gone.
+Future<void> removeLegacyV3StorageArtifacts({
+  SecretStore? store,
+  Directory? cacheDirectory,
+  Directory? documentsDirectory,
+  Directory? temporaryDirectory,
+}) async {
+  final cache = cacheDirectory ?? await getApplicationCacheDirectory();
+  final documents =
+      documentsDirectory ?? await getApplicationDocumentsDirectory();
+  final temporary = temporaryDirectory ?? await getTemporaryDirectory();
+  final secretStore = store ?? FlutterSecretStore();
+
+  var removed = 0;
+
+  for (final dir in [cache, documents]) {
+    removed += await _deleteLegacySqliteIn(dir);
+  }
+  removed += await _deleteLegacyDocumentCaches(temporary);
+
+  try {
+    final existing = await secretStore.read(legacyV3EncryptionKeyName);
+    if (existing != null) {
+      await secretStore.delete(legacyV3EncryptionKeyName);
+      removed++;
+    }
+  } catch (e) {
+    logger.e('Failed to delete legacy encryption_key: $e');
+  }
+
+  if (removed > 0) {
+    logger.i('Removed $removed legacy v3 storage artifact(s)');
+  }
+}
+
+Future<int> _deleteLegacySqliteIn(Directory dir) async {
+  if (!dir.existsSync()) return 0;
+  var removed = 0;
+  try {
+    for (final entity in dir.listSync(followLinks: false)) {
+      if (entity is! File) continue;
+      if (!isLegacyV3SqliteFileName(p.basename(entity.path))) continue;
+      try {
+        await entity.delete();
+        removed++;
+      } catch (e) {
+        logger.e('Failed to delete legacy DB ${entity.path}: $e');
+      }
+    }
+  } catch (e) {
+    logger.e('Failed to scan ${dir.path} for legacy DBs: $e');
+  }
+  return removed;
+}
+
+Future<int> _deleteLegacyDocumentCaches(Directory temporary) async {
+  if (!temporary.existsSync()) return 0;
+  var removed = 0;
+  try {
+    for (final entity in temporary.listSync(followLinks: false)) {
+      if (entity is! Directory) continue;
+      final basename = p.basename(entity.path);
+      if (!_numericDirName.hasMatch(basename)) continue;
+      final documentCache = Directory(p.join(entity.path, 'document_cache'));
+      if (!documentCache.existsSync()) continue;
+      try {
+        await entity.delete(recursive: true);
+        removed++;
+      } catch (e) {
+        logger.e('Failed to delete legacy document cache ${entity.path}: $e');
+      }
+    }
+  } catch (e) {
+    logger.e('Failed to scan ${temporary.path} for legacy document caches: $e');
+  }
+  return removed;
+}

--- a/lib/bridge/login_telemetry.dart
+++ b/lib/bridge/login_telemetry.dart
@@ -1,0 +1,47 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:liblanis/liblanis.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+import '../utils/logger.dart';
+
+/// Authenticate, then fire-and-forget lanis-logger login telemetry when
+/// [withoutData] is false and the app is in release mode (pre-v4 Session
+/// behavior).
+Future<LanisSession> authenticateWithLoginTelemetry(
+  Session sessionController, {
+  bool withoutData = false,
+}) async {
+  final session = await sessionController.authenticate(
+    withoutData: withoutData,
+  );
+  if (!withoutData && kReleaseMode) {
+    asyncLogLoginRequest(session);
+  }
+  return session;
+}
+
+/// Logs the login by schoolID and version code to the orion server.
+///
+/// server repo: https://github.com/lanis-mobile/school-monitor-backend
+void asyncLogLoginRequest(LanisSession session) async {
+  PackageInfo packageInfo = await PackageInfo.fromPlatform();
+  try {
+    String platform = Platform.isAndroid
+        ? 'android'
+        : Platform.isIOS
+        ? 'ios'
+        : 'unknown';
+    await session.dio.post(
+      "https://lanis-logger.orion.alessioc42.dev/api/log-login?schoolid=${session.account.schoolID}&versioncode=${packageInfo.buildNumber}&platform=$platform",
+    );
+    logger.i(
+      'Logged account login to orion. (${session.account.schoolID}, ${packageInfo.buildNumber})',
+    );
+  } catch (e) {
+    logger.w(
+      'Failed to log account login to orion. (${session.account.schoolID}, ${packageInfo.buildNumber}) Likely the user in in a private network which only allows for school portal access.',
+    );
+  }
+}

--- a/lib/features/auth/auth_controller.dart
+++ b/lib/features/auth/auth_controller.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:liblanis/liblanis.dart';
+import 'package:lanis/bridge/login_telemetry.dart';
 import 'package:lanis/utils/privacy_policy.dart';
 
 enum AuthPhase { unauthenticated, authenticating, authenticated, error }
@@ -60,7 +61,7 @@ class AuthController extends Notifier<AuthState> {
       await override(ref);
       return;
     }
-    await ref.read(sessionProvider.notifier).authenticate();
+    await authenticateWithLoginTelemetry(ref.read(sessionProvider.notifier));
   }
 
   Future<void> _deauthenticate() async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,7 @@ import 'package:intl/date_symbol_data_local.dart';
 import 'package:lanis/applets/conversations/view/shared.dart';
 import 'package:lanis/background_service.dart';
 import 'package:lanis/bridge/lanis_bootstrap.dart';
+import 'package:lanis/bridge/legacy_storage_cleanup.dart';
 import 'package:lanis/generated/l10n.dart';
 import 'package:lanis/router.dart';
 import 'package:lanis/themes.dart';
@@ -37,6 +38,7 @@ Future<void> _startApp() async {
       };
     }
 
+    await removeLegacyV3StorageArtifacts();
     final overrides = await bootstrapLanisClient();
     syncGlitchTipReportingFromConfig();
 

--- a/test/bridge/legacy_storage_cleanup_test.dart
+++ b/test/bridge/legacy_storage_cleanup_test.dart
@@ -1,0 +1,105 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lanis/bridge/legacy_storage_cleanup.dart';
+import 'package:liblanis/liblanis.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  group('isLegacyV3SqliteFileName', () {
+    test('matches accounts_database and session_*_db including sidecars', () {
+      expect(isLegacyV3SqliteFileName('accounts_database.sqlite'), isTrue);
+      expect(isLegacyV3SqliteFileName('accounts_database.sqlite-wal'), isTrue);
+      expect(isLegacyV3SqliteFileName('accounts_database.sqlite-shm'), isTrue);
+      expect(isLegacyV3SqliteFileName('session_1_db.sqlite'), isTrue);
+      expect(isLegacyV3SqliteFileName('session_42_db.sqlite-wal'), isTrue);
+    });
+
+    test('ignores v4 and unrelated names', () {
+      expect(isLegacyV3SqliteFileName('lanis.db'), isFalse);
+      expect(isLegacyV3SqliteFileName('lanis.db-wal'), isFalse);
+      expect(isLegacyV3SqliteFileName('session_db.sqlite'), isFalse);
+      expect(isLegacyV3SqliteFileName('other.sqlite'), isFalse);
+    });
+  });
+
+  group('removeLegacyV3StorageArtifacts', () {
+    late Directory root;
+    late Directory cache;
+    late Directory documents;
+    late Directory temporary;
+    late MemorySecretStore store;
+
+    setUp(() {
+      root = Directory.systemTemp.createTempSync('legacy_v3_cleanup_');
+      cache = Directory(p.join(root.path, 'cache'))..createSync();
+      documents = Directory(p.join(root.path, 'documents'))..createSync();
+      temporary = Directory(p.join(root.path, 'temp'))..createSync();
+      store = MemorySecretStore();
+    });
+
+    tearDown(() {
+      if (root.existsSync()) {
+        root.deleteSync(recursive: true);
+      }
+    });
+
+    Future<void> touch(Directory dir, String name) async {
+      File(p.join(dir.path, name)).writeAsStringSync('x');
+    }
+
+    test('deletes legacy DBs and encryption_key; keeps v4 artifacts', () async {
+      await touch(cache, 'accounts_database.sqlite');
+      await touch(cache, 'session_1_db.sqlite-wal');
+      await touch(cache, 'lanis.db');
+      await touch(documents, 'session_2_db.sqlite');
+
+      final legacyDocs = Directory(p.join(temporary.path, '9', 'document_cache'))
+        ..createSync(recursive: true);
+      File(p.join(legacyDocs.path, 'file.bin')).writeAsStringSync('old');
+
+      final v4Docs = Directory(
+        p.join(temporary.path, 'lanis_documents', '1', 'document_cache'),
+      )..createSync(recursive: true);
+      File(p.join(v4Docs.path, 'keep.bin')).writeAsStringSync('new');
+
+      await store.write(legacyV3EncryptionKeyName, 'old-aes-key');
+      await store.write('account_password_1', 'secret');
+
+      await removeLegacyV3StorageArtifacts(
+        store: store,
+        cacheDirectory: cache,
+        documentsDirectory: documents,
+        temporaryDirectory: temporary,
+      );
+
+      expect(File(p.join(cache.path, 'accounts_database.sqlite')).existsSync(), isFalse);
+      expect(File(p.join(cache.path, 'session_1_db.sqlite-wal')).existsSync(), isFalse);
+      expect(File(p.join(documents.path, 'session_2_db.sqlite')).existsSync(), isFalse);
+      expect(Directory(p.join(temporary.path, '9')).existsSync(), isFalse);
+
+      expect(File(p.join(cache.path, 'lanis.db')).existsSync(), isTrue);
+      expect(
+        File(p.join(v4Docs.path, 'keep.bin')).existsSync(),
+        isTrue,
+      );
+      expect(await store.read(legacyV3EncryptionKeyName), isNull);
+      expect(await store.read('account_password_1'), 'secret');
+    });
+
+    test('is a no-op when nothing legacy remains', () async {
+      await touch(cache, 'lanis.db');
+      await store.write('account_password_1', 'secret');
+
+      await removeLegacyV3StorageArtifacts(
+        store: store,
+        cacheDirectory: cache,
+        documentsDirectory: documents,
+        temporaryDirectory: temporary,
+      );
+
+      expect(File(p.join(cache.path, 'lanis.db')).existsSync(), isTrue);
+      expect(await store.read('account_password_1'), 'secret');
+    });
+  });
+}


### PR DESCRIPTION
- Clean up orphaned v3 Drift DBs, old numeric document caches, and `encryption_key` on UI/background startup without touching v4 `lanis.db` or account passwords
- Restore release-only lanis-logger `/api/log-login` telemetry at the Flutter auth layer after full authenticate (same request and constraints as before backend separation)
