### PR TITLE
Fix timetable settings modal popping the wrong navigator.

### DIFF
--- a/lib/applets/timetable/student/student_timetable_settings.dart
+++ b/lib/applets/timetable/student/student_timetable_settings.dart
@@ -261,7 +261,7 @@ class _StudentTimetableSettingsState
                             days[currentDay].add(newLesson);
 
                             updateSettings('custom-lessons', days);
-                            Navigator.of(context).pop();
+                            popRootDialog(context1);
                             showSnackbar(
                               context,
                               AppLocalizations.of(


### PR DESCRIPTION
Closing the custom-lesson sheet used the page context, which removed the settings route and left go_router with an empty match list on Android back.