### PR TITLE
Fix lanis-logger login telemetry User-Agent

### DIFF
--- a/lib/bridge/login_telemetry.dart
+++ b/lib/bridge/login_telemetry.dart
@@ -1,10 +1,17 @@
 import 'dart:io';
 
+import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:liblanis/liblanis.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
 import '../utils/logger.dart';
+
+/// Exact User-Agent required by school-monitor-backend `/api/log-login`.
+///
+/// The session Dio interceptor overwrites this with a versioned agent and also
+/// rejects HTTP 201 via [validateStatus], so telemetry uses a dedicated client.
+const _lanisLoggerUserAgent = 'Lanis-Mobile';
 
 /// Authenticate, then fire-and-forget lanis-logger login telemetry when
 /// [withoutData] is false and the app is in release mode (pre-v4 Session
@@ -33,8 +40,9 @@ void asyncLogLoginRequest(LanisSession session) async {
         : Platform.isIOS
         ? 'ios'
         : 'unknown';
-    await session.dio.post(
+    await Dio().post(
       "https://lanis-logger.orion.alessioc42.dev/api/log-login?schoolid=${session.account.schoolID}&versioncode=${packageInfo.buildNumber}&platform=$platform",
+      options: Options(headers: {'User-Agent': _lanisLoggerUserAgent}),
     );
     logger.i(
       'Logged account login to orion. (${session.account.schoolID}, ${packageInfo.buildNumber})',


### PR DESCRIPTION
## Summary
- Production login telemetry was silently rejected because school-monitor-backend only accepts User-Agent `Lanis-Mobile`, while the session Dio client sends a versioned agent and overwrites per-request headers.
- Session Dio also treats HTTP 201 as failure via `validateStatus`, so even an accepted logger response would surface as a client-side failure.
- Use a dedicated Dio client for `/api/log-login` with the required User-Agent.

## Test plan
- [ ] Release-mode login/bootstrap posts to `https://lanis-logger.orion.alessioc42.dev/api/log-login` with `User-Agent: Lanis-Mobile`
- [ ] Confirm the logger responds with HTTP 201 (not the 200 decoy version payload)
- [ ] Confirm a new Influx `clientloginmesurement` point appears for the school/version/platform
- [ ] SPH requests still use the versioned `Lanis-Mobile/v…` User-Agent