### PR TITLE
Fix login back crash and null attendances fatals

### DIFF
--- a/lib/applets/lessons/student/attendances.dart
+++ b/lib/applets/lessons/student/attendances.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:liblanis/liblanis.dart';
 import 'package:lanis/generated/l10n.dart';
 
-
 class AttendancesScreen extends StatelessWidget {
   const AttendancesScreen({super.key, required this.lessons});
 
@@ -10,10 +9,15 @@ class AttendancesScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Some courses omit attendance maps; never force-unwrap.
+    final attendanceLessons = lessons
+        .where((lesson) => lesson.attendances != null)
+        .toList();
+
     return Scaffold(
       appBar: AppBar(title: Text(AppLocalizations.of(context).attendances)),
       body: ListView.builder(
-        itemCount: lessons.length + 1,
+        itemCount: attendanceLessons.length + 1,
         itemBuilder: (context, index) {
           if (index == 0) {
             return Column(
@@ -21,17 +25,17 @@ class AttendancesScreen extends StatelessWidget {
                 AttendanceCard(
                   title: AppLocalizations.of(context).allAttendances,
                   teachers: [],
-                  attendances: getCombinedAttendances(lessons),
+                  attendances: getCombinedAttendances(attendanceLessons),
                 ),
                 Divider(),
               ],
             );
           }
-          final lesson = lessons[index - 1];
+          final lesson = attendanceLessons[index - 1];
           return AttendanceCard(
             title: lesson.name,
             teachers: lesson.teachers,
-            attendances: lesson.attendances!,
+            attendances: lesson.attendances ?? const {},
           );
         },
       ),
@@ -131,7 +135,9 @@ class AttendanceCard extends StatelessWidget {
 Map<String, String> getCombinedAttendances(Lessons lessons) {
   final attendances = <String, int>{};
   for (final lesson in lessons) {
-    for (final entry in lesson.attendances!.entries) {
+    final lessonAttendances = lesson.attendances;
+    if (lessonAttendances == null) continue;
+    for (final entry in lessonAttendances.entries) {
       final key = entry.key;
       final value = int.tryParse(entry.value) ?? 0;
       attendances.update(key, (val) => val + value, ifAbsent: () => value);

--- a/lib/view/login/auth.dart
+++ b/lib/view/login/auth.dart
@@ -163,7 +163,14 @@ class LoginFormState extends ConsumerState<LoginForm> {
           Padding(
             padding: EdgeInsets.only(right: 32, top: 32),
             child: IconButton(
-              onPressed: () => context.pop(),
+              onPressed: () {
+                // Welcome uses go('/login') (no stack); account switcher uses push.
+                if (context.canPop()) {
+                  context.pop();
+                } else {
+                  context.go('/welcome');
+                }
+              },
               icon: Icon(Icons.arrow_back),
             ),
           ),

--- a/test/applets/attendances_test.dart
+++ b/test/applets/attendances_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liblanis/liblanis.dart';
+import 'package:lanis/applets/lessons/student/attendances.dart';
+
+Lesson _lesson({
+  required String id,
+  Map<String, String>? attendances,
+}) {
+  return Lesson(
+    courseID: id,
+    name: 'Course $id',
+    teachers: const [],
+    courseURL: Uri.parse('https://example.test/$id'),
+    attendances: attendances,
+  );
+}
+
+void main() {
+  test('getCombinedAttendances skips lessons with null attendances', () {
+    final combined = getCombinedAttendances([
+      _lesson(id: 'a', attendances: {'fehlend': '1', 'entschuldigt': '2'}),
+      _lesson(id: 'b'),
+      _lesson(id: 'c', attendances: {'fehlend': '3'}),
+    ]);
+
+    expect(combined, {'fehlend': '4', 'entschuldigt': '2'});
+  });
+
+  test('getCombinedAttendances returns empty map when all null', () {
+    expect(
+      getCombinedAttendances([_lesson(id: 'a'), _lesson(id: 'b')]),
+      isEmpty,
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- Login back used `context.pop()` after welcome navigates with `go('/login')`, which leaves nothing to pop (LANIS-MOBILE-9). Pop when `canPop`, otherwise `go('/welcome')` so account-switcher `push` still works.
- Attendances screen force-unwrapped `lesson.attendances` even when some courses omit it (LANIS-MOBILE-A). Filter null maps and skip them when combining totals.
- Add unit coverage for combined attendance null handling.

## Test plan
- [ ] From welcome → login, tap back: returns to welcome without crash
- [ ] From account switcher → add account/login, tap back: returns to switcher
- [ ] Open lessons attendances when some courses lack attendance data: screen loads, combined totals ignore null lessons
- [ ] `flutter test test/applets/attendances_test.dart test/view/login_form_test.dart`