### PR TITLE
Fix ErrorWidget l10n crash and conversations accountType null fatal.

### DIFF
--- a/lib/applets/conversations/view/conversations_view.dart
+++ b/lib/applets/conversations/view/conversations_view.dart
@@ -706,7 +706,7 @@ class _ConversationsViewState extends ConsumerState<ConversationsView> {
             phpUrl: conversationsDefinition.appletPhpUrl,
             settingsDefaults: conversationsDefinition.settingsDefaults,
             accountType:
-                ref.watch(sessionProvider).asData?.value?.accountType ??
+                ref.watch(sessionProvider).asData?.value?.accountTypeOrNull ??
                 ref.watch(activeAccountProvider)?.accountType ??
                 AccountType.student,
             builder:

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -174,9 +174,8 @@ class App extends ConsumerWidget {
 }
 
 Widget errorWidget(FlutterErrorDetails details, {BuildContext? context}) {
-  if (context != null) AppLocalizations.of(context);
-
-  String error = details.exception.toString();
+  // Hardcoded German copy: ErrorWidget can run before AppLocalizations is loaded.
+  final error = details.exception.toString();
 
   return Container(
     color: const Color.fromARGB(255, 249, 222, 220),
@@ -192,14 +191,14 @@ Widget errorWidget(FlutterErrorDetails details, {BuildContext? context}) {
             color: Color.fromARGB(255, 179, 38, 30),
           ),
           const SizedBox(height: 24),
-          DefaultTextStyle(
-            style: const TextStyle(
+          const DefaultTextStyle(
+            style: TextStyle(
               fontSize: 24,
               fontWeight: FontWeight.bold,
               color: Color.fromARGB(255, 179, 38, 30),
             ),
             child: Text(
-              AppLocalizations.current.errorOccurred,
+              'Ein Fehler ist aufgetreten.',
               textAlign: TextAlign.center,
             ),
           ),
@@ -210,7 +209,7 @@ Widget errorWidget(FlutterErrorDetails details, {BuildContext? context}) {
               color: Color.fromARGB(255, 179, 38, 30),
             ),
             child: Text(
-              AppLocalizations.current.errorOccurredDetails(error),
+              'Problem: $error',
               textAlign: TextAlign.center,
             ),
           ),
@@ -243,7 +242,7 @@ Widget errorWidget(FlutterErrorDetails details, {BuildContext? context}) {
                 return const Color.fromARGB(255, 179, 38, 30);
               }),
             ),
-            child: Text(AppLocalizations.current.copyErrorToClipboard),
+            child: const Text('Fehler in die Zwischenablage kopieren'),
           ),
         ],
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ publish_to: 'none'
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 4.0.3+87
+version: 4.0.4+88
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
Hardcode German ErrorWidget copy so it works before localizations load, and use accountTypeOrNull during account switch. Bump to 4.0.4+88.