### PR TITLE
Fix Category A in-app UI crashes from GlitchTip.

### DIFF
--- a/lib/applets/lessons/student/upload_multipart.dart
+++ b/lib/applets/lessons/student/upload_multipart.dart
@@ -1,0 +1,6 @@
+import 'package:dio/dio.dart';
+
+/// Clone multipart payloads so Dio retries never reuse a finalized stream.
+List<MultipartFile> cloneMultipartFiles(List<MultipartFile> files) {
+  return files.map((file) => file.clone()).toList(growable: false);
+}

--- a/lib/applets/lessons/student/upload_page.dart
+++ b/lib/applets/lessons/student/upload_page.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:liblanis/liblanis.dart';
 import 'package:lanis/applets/lessons/student/upload_dates.dart';
+import 'package:lanis/applets/lessons/student/upload_multipart.dart';
 import 'package:lanis/generated/l10n.dart';
 import 'package:lanis/utils/file_picker.dart';
 import 'package:lanis/utils/root_nav.dart';
@@ -185,16 +186,21 @@ class _UploadScreenState extends ConsumerState<UploadScreen> {
                               List<FileStatus> fileStatus;
 
                               try {
+                                // Clone before each attempt: Dio MultipartFile
+                                // streams can only be finalized once (retry after
+                                // a failed upload would otherwise crash).
+                                final uploadFiles =
+                                    cloneMultipartFiles(_multipartFiles);
                                 fileStatus = await ref.read(lessonsStudentParserProvider)
                                     .uploadFile(
                                       course: snapshot.data["course_id"],
                                       entry: snapshot.data["entry_id"],
                                       upload: snapshot.data["upload_id"],
-                                      file1: _multipartFiles[0],
-                                      file2: _multipartFiles.elementAtOrNull(1),
-                                      file3: _multipartFiles.elementAtOrNull(2),
-                                      file4: _multipartFiles.elementAtOrNull(3),
-                                      file5: _multipartFiles.elementAtOrNull(4),
+                                      file1: uploadFiles[0],
+                                      file2: uploadFiles.elementAtOrNull(1),
+                                      file3: uploadFiles.elementAtOrNull(2),
+                                      file4: uploadFiles.elementAtOrNull(3),
+                                      file5: uploadFiles.elementAtOrNull(4),
                                     );
                               } on LanisException catch (ex) {
                                 if (context.mounted) {

--- a/lib/applets/substitutions/substitutions_listtile.dart
+++ b/lib/applets/substitutions/substitutions_listtile.dart
@@ -12,6 +12,14 @@ class SubstitutionListTile extends StatelessWidget {
     return empty.contains(info);
   }
 
+  /// Prefer [value] when present; otherwise fall back to [valueAlt].
+  /// Returns null when both are blank placeholders.
+  String? primaryOrAlt(String? value, String? valueAlt) {
+    if (!isBlankNotice(value)) return value;
+    if (!isBlankNotice(valueAlt)) return valueAlt;
+    return null;
+  }
+
   Widget? getSubstitutionInfo({
     required BuildContext context,
     required String displayKey,
@@ -19,7 +27,8 @@ class SubstitutionListTile extends StatelessWidget {
     required String? valueAlt,
     required IconData icon,
   }) {
-    if (isBlankNotice(value) && isBlankNotice(valueAlt)) {
+    final displayValue = primaryOrAlt(value, valueAlt);
+    if (displayValue == null) {
       return null;
     }
 
@@ -42,9 +51,7 @@ class SubstitutionListTile extends StatelessWidget {
             ],
           ),
           SubstitutionsFormattedText(
-            !isBlankNotice(value)
-                ? value!
-                : valueAlt!,
+            displayValue,
             Theme.of(context).textTheme.bodyMedium!,
           ),
         ],
@@ -156,52 +163,73 @@ class SubstitutionListTile extends StatelessWidget {
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  if (!isBlankNotice(substitutionData.klasse) || !isBlankNotice(substitutionData.klasse_alt)) ...[
-                    ConstrainedBox(
-                      constraints: BoxConstraints(maxWidth: maxClassWidth),
-                      child: MarqueeWidget(
-                        direction: Axis.horizontal,
-                        child: Row(
-                          spacing: 2,
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            if (isBlankNotice(substitutionData.klasse)) ...[
-                              Icon(
-                                Icons.help_outline_outlined,
-                                size: Theme.of(context).textTheme.titleMedium?.fontSize,
+                  Builder(
+                    builder: (context) {
+                      final klasseLabel = primaryOrAlt(
+                        substitutionData.klasse,
+                        substitutionData.klasse_alt,
+                      );
+                      if (klasseLabel == null) {
+                        return const SizedBox.shrink();
+                      }
+                      return ConstrainedBox(
+                        constraints: BoxConstraints(maxWidth: maxClassWidth),
+                        child: MarqueeWidget(
+                          direction: Axis.horizontal,
+                          child: Row(
+                            spacing: 2,
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              if (isBlankNotice(substitutionData.klasse)) ...[
+                                Icon(
+                                  Icons.help_outline_outlined,
+                                  size: Theme.of(context)
+                                      .textTheme
+                                      .titleMedium
+                                      ?.fontSize,
+                                ),
+                              ],
+                              Text(
+                                klasseLabel,
+                                style: Theme.of(context).textTheme.titleMedium,
+                                overflow: TextOverflow.ellipsis,
                               ),
                             ],
-                            Text(
-                              substitutionData.klasse!,
-                              style: Theme.of(context).textTheme.titleMedium,
-                              overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                  Builder(
+                    builder: (context) {
+                      final fachLabel = primaryOrAlt(
+                        substitutionData.fach,
+                        substitutionData.fach_alt,
+                      );
+                      if (fachLabel == null) {
+                        return const SizedBox.shrink();
+                      }
+                      return Row(
+                        spacing: 2,
+                        mainAxisSize: .min,
+                        children: [
+                          if (isBlankNotice(substitutionData.fach)) ...[
+                            Icon(
+                              Icons.help_outline_outlined,
+                              size: Theme.of(context)
+                                  .textTheme
+                                  .titleLarge
+                                  ?.fontSize,
                             ),
                           ],
-                        ),
-                      ),
-                    ),
-                  ],
-                  if (!isBlankNotice(substitutionData.fach) || !isBlankNotice(substitutionData.fach_alt)) ...[
-                    Row(
-                      spacing: 2,
-                      mainAxisSize: .min,
-                      children: [
-                        if (isBlankNotice(substitutionData.fach)) ...[
-                          Icon(
-                            Icons.help_outline_outlined,
-                            size: Theme.of(context).textTheme.titleLarge?.fontSize,
+                          Text(
+                            fachLabel,
+                            style: Theme.of(context).textTheme.titleLarge,
                           ),
                         ],
-                        Text(
-                          // prioritize new subject over old subject
-                          !isBlankNotice(substitutionData.fach)
-                              ? substitutionData.fach!
-                              : substitutionData.fach_alt!,
-                          style: Theme.of(context).textTheme.titleLarge,
-                        ),
-                      ],
-                    ),
-                  ],
+                      );
+                    },
+                  ),
                   if (!isBlankNotice(substitutionData.stunde)) ...[
                     Text(
                       substitutionData.stunde,

--- a/lib/applets/timetable/student/student_timetable_better_view.dart
+++ b/lib/applets/timetable/student/student_timetable_better_view.dart
@@ -9,6 +9,7 @@ import 'package:intl/intl.dart';
 import 'package:lanis/applets/timetable/definition.dart';
 import 'package:lanis/applets/timetable/student/student_timetable_item.dart';
 import 'package:lanis/applets/timetable/student/timetable_helper.dart';
+import 'package:lanis/applets/timetable/student/timetable_week_selection.dart';
 import 'package:lanis/generated/l10n.dart';
 import 'package:lanis/l10n/account_type_ui.dart';
 import 'package:lanis/widgets/combined_applet_builder.dart';
@@ -108,16 +109,23 @@ class _StudentTimetableBetterViewState
                 .toList();
 
             if (currentWeekIndex == -1) {
-              currentWeekIndex = (showByWeek || timetable.weekBadge == null)
-                  ? 0
-                  : uniqueBadges.indexOf(timetable.weekBadge!) + 1;
+              currentWeekIndex = initialTimetableWeekIndex(
+                showByWeek: showByWeek,
+                weekBadge: timetable.weekBadge,
+                uniqueBadges: uniqueBadges,
+              );
             }
+            final weekSelection = resolveTimetableWeekSelection(
+              currentWeekIndex: currentWeekIndex,
+              uniqueBadges: uniqueBadges,
+            );
+            currentWeekIndex = weekSelection.index;
 
             TimeTableData data = TimeTableData(
               selectedPlan,
               timetable,
               settings,
-              currentWeekIndex == 0 ? null : uniqueBadges[currentWeekIndex - 1],
+              weekSelection.badge,
             );
 
             headerHeight =
@@ -179,7 +187,10 @@ class _StudentTimetableBetterViewState
                     ],
             );
 
-            if (data.hours.isEmpty) {
+            if (isTimetableVisuallyEmpty(
+              hoursEmpty: data.hours.isEmpty,
+              daysEmpty: data.timetableDays.isEmpty,
+            )) {
               return Scaffold(
                 appBar: appBar,
                 body: RefreshIndicator(
@@ -414,6 +425,9 @@ class TimeTableView extends StatelessWidget {
                           }).toList(),
                         );
                       } else {
+                        if (days.isEmpty) {
+                          return const SizedBox.shrink();
+                        }
                         var initialIndex = (DateTime.now().weekday - 1) % 7;
                         if (initialIndex >= days.length) {
                           initialIndex = 0;
@@ -578,6 +592,10 @@ class _TimeMarkerWidgetState extends ConsumerState<TimeMarkerWidget> {
 
     if (currentDay != widget.day) {
       return SizedBox();
+    }
+
+    if (widget.data.hours.isEmpty || widget.data.timetableDays.isEmpty) {
+      return const SizedBox();
     }
 
     if (nowTod < widget.data.hours.first.startTime) {

--- a/lib/applets/timetable/student/student_timetable_settings.dart
+++ b/lib/applets/timetable/student/student_timetable_settings.dart
@@ -36,9 +36,9 @@ class _StudentTimetableSettingsState
     TimeTableType selectedType,
   ) {
     if (selectedType == TimeTableType.own) {
-      return data.planForOwn!;
+      return data.planForOwn ?? const [];
     }
-    return data.planForAll!;
+    return data.planForAll ?? const [];
   }
 
   void showCustomLessonDialog(
@@ -51,7 +51,11 @@ class _StudentTimetableSettingsState
   }) {
     List<TimeTableRow>? hours = currentTimetable.hours;
     if (hours == null || hours.length <= 1) {
-      throw Exception('hours is null or too short');
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(AppLocalizations.of(context).noDataFound)),
+      );
+      return;
     }
     TimeTableRow startTime = hours[0];
     TimeTableRow endTime = hours[1];

--- a/lib/applets/timetable/student/timetable_week_selection.dart
+++ b/lib/applets/timetable/student/timetable_week_selection.dart
@@ -1,0 +1,41 @@
+/// Resolves the selected week badge for the student timetable.
+///
+/// [currentWeekIndex] uses `0` for "all weeks" and `1..n` for
+/// [uniqueBadges] entries. Out-of-range / empty badge lists fall back to
+/// "all weeks" so UI builds never index an empty list.
+({int index, String? badge}) resolveTimetableWeekSelection({
+  required int currentWeekIndex,
+  required List<String> uniqueBadges,
+}) {
+  if (uniqueBadges.isEmpty || currentWeekIndex <= 0) {
+    return (index: 0, badge: null);
+  }
+  if (currentWeekIndex > uniqueBadges.length) {
+    return (index: 0, badge: null);
+  }
+  return (
+    index: currentWeekIndex,
+    badge: uniqueBadges[currentWeekIndex - 1],
+  );
+}
+
+/// Initial week index from settings / current school week badge.
+int initialTimetableWeekIndex({
+  required bool showByWeek,
+  required String? weekBadge,
+  required List<String> uniqueBadges,
+}) {
+  if (showByWeek || weekBadge == null || weekBadge.isEmpty) {
+    return 0;
+  }
+  final idx = uniqueBadges.indexOf(weekBadge);
+  return idx >= 0 ? idx + 1 : 0;
+}
+
+/// True when the timetable has hour rows but no visible day columns after
+/// week / hidden-lesson filtering (would crash [DefaultTabController]).
+bool isTimetableVisuallyEmpty({
+  required bool hoursEmpty,
+  required bool daysEmpty,
+}) =>
+    hoursEmpty || daysEmpty;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -132,31 +132,37 @@ class App extends ConsumerWidget {
           Themes.dynamicTheme = Themes.getNewTheme(lightDynamic.primary);
         }
         if (snapshot['color'] == 'dynamic') {
-          var dynamicTheme = Themes.dynamicTheme;
-          var darkTheme = dynamicTheme.darkTheme;
-          if (snapshot['is-amoled'] == true) {
-            darkTheme = Themes.getAmoledThemes(dynamicTheme).darkTheme;
+          final dynamicTheme = Themes.dynamicTheme;
+          // DynamicColorBuilder may call this before platform colors exist;
+          // keep the already-selected fallback theme instead of null themes.
+          if (dynamicTheme.lightTheme != null) {
+            var darkTheme = dynamicTheme.darkTheme;
+            if (snapshot['is-amoled'] == true) {
+              darkTheme = Themes.getAmoledThemes(dynamicTheme).darkTheme;
+            }
+            theme = Themes(dynamicTheme.lightTheme, darkTheme);
           }
-          theme = Themes(dynamicTheme.lightTheme, darkTheme);
         }
 
+        final lightTheme =
+            theme.lightTheme ?? Themes.standardTheme.lightTheme!;
+        final darkTheme =
+            theme.darkTheme ?? Themes.standardTheme.darkTheme!;
         if (mode == ThemeMode.light ||
             (mode == ThemeMode.system &&
                 MediaQuery.of(context).platformBrightness ==
                     Brightness.light)) {
-          BubbleStyles.init(theme.lightTheme!);
+          BubbleStyles.init(lightTheme);
         } else if (mode == ThemeMode.dark ||
             (mode == ThemeMode.system &&
                 MediaQuery.of(context).platformBrightness == Brightness.dark)) {
-          BubbleStyles.init(
-            theme.darkTheme ?? Themes.standardTheme.darkTheme!,
-          );
+          BubbleStyles.init(darkTheme);
         }
 
         return MaterialApp.router(
           title: 'Lanis Mobile',
-          theme: theme.lightTheme,
-          darkTheme: theme.darkTheme,
+          theme: lightTheme,
+          darkTheme: darkTheme,
           themeMode: mode,
           routerConfig: router,
           localizationsDelegates: const [

--- a/lib/utils/cached_network_image.dart
+++ b/lib/utils/cached_network_image.dart
@@ -33,12 +33,17 @@ class _CachedNetworkImageState extends ConsumerState<CachedNetworkImage> {
   bool loading = true;
   late ImageProvider imageProvider;
 
+  void _safeSetLoading(bool value) {
+    if (!mounted) return;
+    setState(() {
+      loading = value;
+    });
+  }
+
   Future<void> loadData() async {
     final storage = ref.read(storageManagerProvider);
     if (storage == null) {
-      setState(() {
-        loading = true;
-      });
+      _safeSetLoading(true);
       return;
     }
     try {
@@ -47,15 +52,12 @@ class _CachedNetworkImageState extends ConsumerState<CachedNetworkImage> {
         'image.${widget.imageType.toString().split('.').last}',
         followRedirects: true,
       );
+      if (!mounted) return;
       File imageFile = File(imagePath);
       imageProvider = FileImage(imageFile);
-      setState(() {
-        loading = false;
-      });
+      _safeSetLoading(false);
     } catch (_) {
-      setState(() {
-        loading = true;
-      });
+      _safeSetLoading(true);
     }
   }
 
@@ -70,14 +72,10 @@ class _CachedNetworkImageState extends ConsumerState<CachedNetworkImage> {
         Uint8List bytes = base64Decode(base64Data);
 
         imageProvider = MemoryImage(bytes);
-        setState(() {
-          loading = false;
-        });
+        _safeSetLoading(false);
       }
     } catch (e) {
-      setState(() {
-        loading = true;
-      });
+      _safeSetLoading(true);
     }
   }
 

--- a/lib/widgets/marquee.dart
+++ b/lib/widgets/marquee.dart
@@ -20,6 +20,7 @@ class MarqueeWidget extends StatefulWidget {
 
 class _MarqueeWidgetState extends State<MarqueeWidget> {
   late ScrollController scrollController;
+  bool _active = true;
 
   @override
   void initState() {
@@ -30,6 +31,7 @@ class _MarqueeWidgetState extends State<MarqueeWidget> {
 
   @override
   void dispose() {
+    _active = false;
     scrollController.dispose();
     super.dispose();
   }
@@ -45,23 +47,22 @@ class _MarqueeWidgetState extends State<MarqueeWidget> {
   }
 
   void scroll(_) async {
-    while (scrollController.hasClients) {
+    while (_active && scrollController.hasClients) {
       await Future.delayed(widget.pauseDuration);
-      if (scrollController.hasClients) {
-        await scrollController.animateTo(
-          scrollController.position.maxScrollExtent,
-          duration: widget.animationDuration,
-          curve: Curves.ease,
-        );
-      }
+      if (!_active || !scrollController.hasClients) return;
+      await scrollController.animateTo(
+        scrollController.position.maxScrollExtent,
+        duration: widget.animationDuration,
+        curve: Curves.ease,
+      );
+      if (!_active) return;
       await Future.delayed(widget.pauseDuration);
-      if (scrollController.hasClients) {
-        await scrollController.animateTo(
-          0.0,
-          duration: widget.backDuration,
-          curve: Curves.easeOut,
-        );
-      }
+      if (!_active || !scrollController.hasClients) return;
+      await scrollController.animateTo(
+        0.0,
+        duration: widget.backDuration,
+        curve: Curves.easeOut,
+      );
     }
   }
 }

--- a/test/applets/substitutions_listtile_test.dart
+++ b/test/applets/substitutions_listtile_test.dart
@@ -1,0 +1,160 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liblanis/liblanis.dart';
+import 'package:lanis/applets/substitutions/substitutions_listtile.dart';
+
+import '../helpers/test_app.dart';
+
+Substitution _sub({
+  String? klasse,
+  String? klasseAlt,
+  String? fach,
+  String? fachAlt,
+  String? raum,
+  String? raumAlt,
+  String? vertreter,
+  String? lehrer,
+  String? hinweis,
+  String? art,
+  String stunde = '1',
+}) {
+  return Substitution(
+    tag: '11.08.2026',
+    tag_en: '2026-08-11',
+    stunde: stunde,
+    klasse: klasse,
+    klasse_alt: klasseAlt,
+    fach: fach,
+    fach_alt: fachAlt,
+    raum: raum,
+    raum_alt: raumAlt,
+    vertreter: vertreter,
+    lehrer: lehrer,
+    hinweis: hinweis,
+    art: art,
+  );
+}
+
+Future<void> _pumpTile(WidgetTester tester, Substitution sub) async {
+  await pumpTestApp(
+    tester,
+    child: Scaffold(body: SubstitutionListTile(substitutionData: sub)),
+  );
+}
+
+/// MarqueeWidget schedules pause timers; dispose + advance time to clear them.
+Future<void> _drainMarquee(WidgetTester tester) async {
+  await tester.pumpWidget(const SizedBox.shrink());
+  // Cover pauseDuration (800ms) after dispose sets _active=false.
+  await tester.pump(const Duration(milliseconds: 900));
+  await tester.pump(const Duration(milliseconds: 900));
+}
+
+void main() {
+  tearDown(LanisClient.reset);
+
+  testWidgets(
+    'klasse_alt fallback renders alt class and help icon without crashing',
+    (tester) async {
+      await _pumpTile(
+        tester,
+        _sub(klasse: null, klasseAlt: '7a', fach: 'M', art: 'Vertretung'),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('7a'), findsOneWidget);
+      expect(find.byIcon(Icons.help_outline_outlined), findsWidgets);
+      expect(find.text('M'), findsOneWidget);
+      expect(find.text('Vertretung'), findsOneWidget);
+      await _drainMarquee(tester);
+    },
+  );
+
+  testWidgets('blank klasse placeholders ("-") fall back to klasse_alt', (
+    tester,
+  ) async {
+    await _pumpTile(tester, _sub(klasse: '-', klasseAlt: 'Q1', fach: 'D'));
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Q1'), findsOneWidget);
+    expect(find.text('-'), findsNothing);
+    await _drainMarquee(tester);
+  });
+
+  testWidgets('blank klasse "---" and " " fall back to klasse_alt', (
+    tester,
+  ) async {
+    for (final blank in ['---', ' ']) {
+      await _pumpTile(tester, _sub(klasse: blank, klasseAlt: '8b', fach: 'E'));
+      expect(tester.takeException(), isNull);
+      expect(find.text('8b'), findsOneWidget);
+      await _drainMarquee(tester);
+    }
+  });
+
+  testWidgets('prefers klasse over klasse_alt when both present', (tester) async {
+    await _pumpTile(tester, _sub(klasse: '9c', klasseAlt: 'alt', fach: 'M'));
+
+    expect(find.text('9c'), findsOneWidget);
+    expect(find.text('alt'), findsNothing);
+    await _drainMarquee(tester);
+  });
+
+  testWidgets('omits class row when klasse and klasse_alt are blank', (
+    tester,
+  ) async {
+    await _pumpTile(tester, _sub(klasse: null, klasseAlt: '-', fach: 'M'));
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('M'), findsOneWidget);
+    expect(find.byIcon(Icons.help_outline_outlined), findsNothing);
+    await _drainMarquee(tester);
+  });
+
+  testWidgets('fach_alt fallback and raum_alt info render', (tester) async {
+    await _pumpTile(
+      tester,
+      _sub(
+        fach: null,
+        fachAlt: 'Bio',
+        raum: '-',
+        raumAlt: 'R101',
+        art: 'Raumänderung',
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Bio'), findsOneWidget);
+    expect(find.text('Raum'), findsOneWidget);
+    expect(find.text('R101', findRichText: true), findsOneWidget);
+    await _drainMarquee(tester);
+  });
+
+  testWidgets('hinweis-only and art-null tiles still build', (tester) async {
+    await _pumpTile(
+      tester,
+      _sub(
+        art: null,
+        hinweis: 'Bitte im Lehrerzimmer melden',
+        stunde: '3 - 4',
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Bitte im Lehrerzimmer melden'), findsOneWidget);
+    expect(find.text('3 - 4'), findsOneWidget);
+    await _drainMarquee(tester);
+  });
+
+  test('primaryOrAlt unit matrix covers blank placeholders', () {
+    final tile = SubstitutionListTile(substitutionData: _sub());
+    expect(tile.primaryOrAlt(null, '7a'), '7a');
+    expect(tile.primaryOrAlt('-', '7a'), '7a');
+    expect(tile.primaryOrAlt('---', '7a'), '7a');
+    expect(tile.primaryOrAlt(' ', '7a'), '7a');
+    expect(tile.primaryOrAlt('', '7a'), '7a');
+    expect(tile.primaryOrAlt('9a', '7a'), '9a');
+    expect(tile.primaryOrAlt(null, null), isNull);
+    expect(tile.primaryOrAlt('-', '---'), isNull);
+  });
+}

--- a/test/applets/timetable_week_selection_test.dart
+++ b/test/applets/timetable_week_selection_test.dart
@@ -1,0 +1,151 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liblanis/liblanis.dart';
+import 'package:lanis/applets/timetable/student/timetable_week_selection.dart';
+
+void main() {
+  group('resolveTimetableWeekSelection', () {
+    test('stale index into empty badges falls back to all weeks', () {
+      final result = resolveTimetableWeekSelection(
+        currentWeekIndex: 2,
+        uniqueBadges: const [],
+      );
+
+      expect(result.index, 0);
+      expect(result.badge, isNull);
+    });
+
+    test('index beyond badge length falls back to all weeks', () {
+      final result = resolveTimetableWeekSelection(
+        currentWeekIndex: 5,
+        uniqueBadges: const ['A', 'B'],
+      );
+      expect(result.index, 0);
+      expect(result.badge, isNull);
+    });
+
+    test('valid index returns matching badge', () {
+      final result = resolveTimetableWeekSelection(
+        currentWeekIndex: 2,
+        uniqueBadges: const ['A', 'B'],
+      );
+      expect(result.index, 2);
+      expect(result.badge, 'B');
+    });
+
+    test('zero and negative indexes mean all weeks', () {
+      expect(
+        resolveTimetableWeekSelection(
+          currentWeekIndex: 0,
+          uniqueBadges: const ['A'],
+        ).badge,
+        isNull,
+      );
+      expect(
+        resolveTimetableWeekSelection(
+          currentWeekIndex: -1,
+          uniqueBadges: const ['A'],
+        ).index,
+        0,
+      );
+    });
+  });
+
+  group('initialTimetableWeekIndex', () {
+    test('unknown weekBadge does not produce negative/out-of-range index', () {
+      expect(
+        initialTimetableWeekIndex(
+          showByWeek: false,
+          weekBadge: 'Z',
+          uniqueBadges: const ['A', 'B'],
+        ),
+        0,
+      );
+    });
+
+    test('known weekBadge maps to 1-based index', () {
+      expect(
+        initialTimetableWeekIndex(
+          showByWeek: false,
+          weekBadge: 'B',
+          uniqueBadges: const ['A', 'B'],
+        ),
+        2,
+      );
+    });
+
+    test('showByWeek forces all-weeks index', () {
+      expect(
+        initialTimetableWeekIndex(
+          showByWeek: true,
+          weekBadge: 'A',
+          uniqueBadges: const ['A'],
+        ),
+        0,
+      );
+    });
+  });
+
+  group('isTimetableVisuallyEmpty', () {
+    test('hours present but days filtered empty is empty UI', () {
+      expect(
+        isTimetableVisuallyEmpty(hoursEmpty: false, daysEmpty: true),
+        isTrue,
+      );
+      expect(
+        isTimetableVisuallyEmpty(hoursEmpty: true, daysEmpty: false),
+        isTrue,
+      );
+      expect(
+        isTimetableVisuallyEmpty(hoursEmpty: false, daysEmpty: false),
+        isFalse,
+      );
+    });
+  });
+
+  test('TimeTableData with unmatched weekBadge yields empty days', () {
+    final hour = TimeTableRow(
+      TimeTableRowType.lesson,
+      const SphTimeOfDay(hour: 8, minute: 0),
+      const SphTimeOfDay(hour: 8, minute: 45),
+      '1',
+      1,
+    );
+    final subject = TimetableSubject(
+      id: 'm-0-0',
+      name: 'Mathe',
+      raum: 'R1',
+      lehrer: 'Mu',
+      badge: 'A',
+      duration: 1,
+      startTime: hour.startTime,
+      endTime: hour.endTime,
+      stunde: 0,
+    );
+    final timetable = TimeTable(
+      planForAll: [
+        [subject],
+      ],
+      hours: [hour],
+      weekBadge: 'A',
+    );
+
+    final data = TimeTableData(
+      [
+        [subject],
+      ],
+      timetable,
+      const {},
+      'B', // filter to a week with no lessons
+    );
+
+    expect(data.hours, isNotEmpty);
+    expect(data.timetableDays, isEmpty);
+    expect(
+      isTimetableVisuallyEmpty(
+        hoursEmpty: data.hours.isEmpty,
+        daysEmpty: data.timetableDays.isEmpty,
+      ),
+      isTrue,
+    );
+  });
+}

--- a/test/applets/upload_multipart_test.dart
+++ b/test/applets/upload_multipart_test.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lanis/applets/lessons/student/upload_multipart.dart';
+
+void main() {
+  test('cloneMultipartFiles allows finalize after original was finalized', () async {
+    final original = MultipartFile.fromBytes(
+      utf8.encode('hello'),
+      filename: 'a.txt',
+    );
+
+    // Simulate first failed request consuming the stream.
+    await original.finalize().fold<List<int>>(
+      <int>[],
+      (prev, chunk) => prev..addAll(chunk),
+    );
+
+    expect(
+      () => original.finalize(),
+      throwsA(isA<StateError>()),
+    );
+
+    final clones = cloneMultipartFiles([original, original]);
+    expect(clones, hasLength(2));
+
+    final first = await clones[0].finalize().fold<List<int>>(
+      <int>[],
+      (prev, chunk) => prev..addAll(chunk),
+    );
+    final second = await clones[1].finalize().fold<List<int>>(
+      <int>[],
+      (prev, chunk) => prev..addAll(chunk),
+    );
+
+    expect(utf8.decode(first), 'hello');
+    expect(utf8.decode(second), 'hello');
+  });
+}

--- a/test/themes_dynamic_fallback_test.dart
+++ b/test/themes_dynamic_fallback_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lanis/themes.dart';
+
+void main() {
+  test('dynamic theme null lightTheme can fall back to standard', () {
+    // Reset to the production default uninitialized dynamic theme.
+    Themes.dynamicTheme = Themes(null, null);
+
+    Themes theme = Themes.standardTheme;
+    final dynamicTheme = Themes.dynamicTheme;
+    if (dynamicTheme.lightTheme != null) {
+      theme = Themes(dynamicTheme.lightTheme, dynamicTheme.darkTheme);
+    }
+
+    final lightTheme = theme.lightTheme ?? Themes.standardTheme.lightTheme!;
+    final darkTheme = theme.darkTheme ?? Themes.standardTheme.darkTheme!;
+
+    expect(lightTheme, isNotNull);
+    expect(darkTheme, isNotNull);
+    expect(theme.lightTheme, Themes.standardTheme.lightTheme);
+  });
+}

--- a/test/utils/cached_network_image_test.dart
+++ b/test/utils/cached_network_image_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liblanis/liblanis.dart';
+import 'package:lanis/utils/cached_network_image.dart';
+
+import '../helpers/test_app.dart';
+
+void main() {
+  tearDown(LanisClient.reset);
+
+  testWidgets('dispose during load does not throw setState-after-dispose', (
+    tester,
+  ) async {
+    await pumpTestApp(
+      tester,
+      child: CachedNetworkImage(
+        placeholder: const Text('placeholder'),
+        imageUrl: Uri.parse('https://example.test/school.jpg'),
+        builder: (context, image) => Image(image: image),
+      ),
+    );
+
+    expect(find.text('placeholder'), findsOneWidget);
+
+    // Dispose widget while async loadData may still be in flight.
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('malformed data URI payload stays on placeholder', (tester) async {
+    // Construct without Uri.parse so invalid base64 reaches _loadBase64Data.
+    final badDataUri = Uri(scheme: 'data', path: 'image/png;base64,@@@');
+    await pumpTestApp(
+      tester,
+      child: CachedNetworkImage(
+        placeholder: const Text('placeholder'),
+        imageUrl: badDataUri,
+        builder: (context, image) => const Text('loaded'),
+      ),
+    );
+
+    expect(find.text('placeholder'), findsOneWidget);
+    expect(find.text('loaded'), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
Harden substitutions, timetable, uploads, themes, cached images, and marquee against null/empty/dispose edge cases that crash production 4.0.6, with regression tests covering rendered UI.