### PR TITLE
Fix duplicate substitution days via liblanis 0.1.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ publish_to: 'none'
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 4.0.7+91
+version: 4.0.8+92
 
 environment:
   sdk: ^3.10.0
@@ -23,7 +23,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  liblanis: any
+  liblanis: ^0.1.2
   flutter_riverpod: ^3.0.3
   go_router: ^16.0.0
   dio_cookie_manager: ^3.3.0


### PR DESCRIPTION
## Summary
- Pin `liblanis` to `^0.1.2` so personal-plan shells no longer duplicate substitution days (underscore `data-tag` vs `#tagDD_MM_YYYY` panels).
- Bump the app to **4.0.8+92** (above current `4.0.7+91`).

Parser change: https://pub.dev/packages/liblanis/versions/0.1.2

## Test plan
- [ ] `flutter pub get` resolves `liblanis` 0.1.2
- [ ] Open Vertretungsplan on an account with a personal plan (day buttons like `data-tag="11_08_2026"`)
- [ ] Confirm each date appears once (no duplicate tabs/entries)