### PR TITLE
Add missing German translation for actionContinue

### DIFF
--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -71,6 +71,7 @@
   "downloading": "Downloaden...",
   "teacher": "Lehrer",
   "clearAll": "Alles löschen",
+  "actionContinue": "Weiter",
   "back": "Zurück",
   "create": "Erstellen",
   "refresh": "Aktualisieren",


### PR DESCRIPTION
## Problem

On the last onboarding page, the **Continue** button renders in English even though the rest of the app is in German.

The button text comes from `AppLocalizations.of(context).actionContinue` (`lib/view/login/screen.dart:89`). The `actionContinue` key exists in `intl_en.arb` but was missing from `intl_de.arb`, so the generated German lookup had no entry and `Intl.message` fell back to the English default literal.

## Fix

Adds `"actionContinue": "Weiter"` to `lib/l10n/intl_de.arb`.

Regenerating (`dart run intl_utils:generate`) picks it up; `lib/generated/` is gitignored so no generated files are included here.

## Note

`actionContinue` is not the only gap — 42 other keys present in `intl_en.arb` have no German counterpart and silently render in English (e.g. `welcomeBack`, `pushNotifications`, `startupRetryButton`). This PR intentionally covers only `actionContinue`; happy to open a follow-up for the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)