### PR TITLE
Fix GitHub link in app error view

### DIFF
--- a/lib/widgets/error_view.dart
+++ b/lib/widgets/error_view.dart
@@ -63,7 +63,7 @@ class AppletErrorView extends StatelessWidget {
               OutlinedButton(
                 onPressed: () {
                   launchUrl(
-                    Uri.parse("https://github.com/alessioC42/lanis/issues"),
+                    Uri.parse("https://github.com/lanis-mobile/lanis/issues"),
                   );
                 },
                 child: const Text("GitHub"),


### PR DESCRIPTION
The GitHub button in AppletErrorView pointed to https://github.com/alessioC42/lanis/issues, which returns 404. Update it to https://github.com/lanis-mobile/lanis/issues. Related to #540. 