### PR TITLE
docs: split README into German and English versions

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,126 @@
+# Lanis Mobile
+
+*[Auf Deutsch lesen](README.md)*
+
+Your app for the Hessian school portal! In cooperation with the state school authority for the Groß-Gerau district and the Main-Taunus district.
+**In use at numerous schools in Hesse with over 35 thousand daily users.**
+
+<p align="center">
+    <img src="https://github.com/alessioC42/lanis-mobile/assets/84250128/19d30436-32f7-4cbe-b78e-f2fee3583c28" width="60%">
+</p>
+
+<table>
+    <tr>
+        <td colspan='2'>
+            <a href='https://play.google.com/store/apps/details?id=io.github.alessioc42.sph&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png' style='height: 71px'/></a>
+        </td>
+        <td colspan='2'>
+            <a href="https://apt.izzysoft.de/fdroid/index/apk/io.github.alessioc42.sph"><img src="https://www.martinstoeckli.ch/images/izzy-on-droid-badge-en.png" alt="Get it on IzzyOnDroid" style="height: 56px;"></a>
+        </td>
+        <td colspan='2'>
+            <a href='https://apps.apple.com/de/app/lanis-mobile/id6511247743?l=en-GB'><img alt='Download on the App Store' src='https://lanis-mobile.github.io/assets/ios-badge.svg' style='height: 61px'/></a>
+        </td>
+    </tr>
+    <tr>
+        <td colspan='3'>
+            <a href='https://lanis-mobile.github.io/'>website</a>
+        </td>
+        <td colspan='3'>
+            <a href='https://discord.gg/MGYaSetUsY'>discord</a>
+        </td>
+    </tr>
+</table>
+
+<p></p>
+<details>
+  <summary>Screenshots</summary>
+<div style="text-align: center;">
+  <img src="fastlane/metadata/android/en-US/images/phoneScreenshots/01.png" width="250" >
+  <img src="fastlane/metadata/android/en-US/images/phoneScreenshots/02.png" width="250" >
+  <img src="fastlane/metadata/android/en-US/images/phoneScreenshots/03.png" width="250" >
+  <img src="fastlane/metadata/android/en-US/images/phoneScreenshots/04.png" width="250" >
+  <img src="fastlane/metadata/android/en-US/images/phoneScreenshots/05.png" width="250" >
+  <img src="fastlane/metadata/android/en-US/images/phoneScreenshots/06.png" width="250" >
+  <img src="fastlane/metadata/android/en-US/images/phoneScreenshots/07.png" width="250" >
+
+</div>
+</details>
+
+## Contributing
+This project relies heavily on bug reports from other schools and on new contributors. The reason for this lies in
+the modular nature of the school portal, which makes it extremely difficult to develop a universal Lanis app.
+
+Don't hesitate to open a bug report if you find an issue. We're always open to new contributors/students working with us to improve the app.
+
+Bug reports can also be sent to <a href="mailto:lanis-mobile@alessioc42.dev">this</a> email address if you don't have a GitHub account.
+
+## Get started with development
+### 1. [Setup Flutter](https://docs.flutter.dev/get-started/quick) with your favourite IDE (Android Studio / VScode recommended)
+
+### 2. Generate the code
+```shell
+dart run build_runner build # Database
+dart run intl_utils:generate # Localisations
+```
+### 3. Development
+Note the flags here:
+#### `--dart-define=cronetHttpNoPlay=true`
+**[Partially optional]**
+This flag is used to include the Cronet binary for networking on non-Play-Services-enabled devices (we also ship this version on the Play Store).
+
+If you are currently using the default Android emulator image, consider using an AOSP image instead, as these tend to perform much better than versions with Play Services enabled.
+
+On iOS builds this flag is not required.
+
+#### `--dart-define=ANSI=true`
+**[Optional]**
+This flag allows the application's logs to be colorized, which can help a lot if you are not already using your IDE's log-filtering tools. (Recommended to omit on macOS due to lack of support in the default Terminal.)
+
+```shell
+flutter run --dart-define=cronetHttpNoPlay=true --dart-define=ANSI=true
+```
+
+### 4. Production
+For actual release mode signing is required, which can be added via placing the respective `key.properties` and `local.properties` in the `android` directory. On iOS the Development team has to be changed in Xcode.
+
+If you are producing a build that you intend to distribute to other people, please consider changing the app ID from `io.github.alessioc42.sph` to `io.github.alessioc42.sph.<fork|dev>.<YOUR_NAME>` or any other name that is different from the original app ID. This will prevent conflicts with the store versions that we are publishing.
+
+```shell
+flutter build <apk|aab|ipa> --release --dart-define=cronetHttpNoPlay=true
+```
+
+An alternative is the interactive `build.py` script, which can build Android and/or iOS in one run, copy artifacts into `artifacts/`, and optionally upload to App Store Connect / Google Play:
+
+```shell
+python3 build.py
+# or non-interactive:
+python3 build.py --android --ios --skip-upgrade --yes
+```
+
+#### Store uploads (optional)
+
+`build.py` loads secrets from gitignored `.env` / `.build.env` in the repo root (real environment variables win). Example:
+
+```env
+ASC_API_KEY_ID=XXXXXXXXXX
+ASC_API_ISSUER_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+ASC_API_KEY_PATH=/path/to/AuthKey_XXXXXXXXXX.p8
+PLAY_SERVICE_ACCOUNT_JSON=/path/to/service-account.json
+```
+
+Extra file: `python3 build.py --env-file /path/to/secrets.env`.
+
+For Play uploads, install the optional Python deps and use a Google Cloud service account that has been invited in Play Console (Users and permissions) with permission to manage tracks:
+
+```shell
+pip install -r requirements-build.txt
+python3 build.py --android --upload-android --play-track internal --yes
+```
+
+For App Store Connect uploads (macOS + Xcode), create an App Store Connect API key, put the values in `.env` (or export them), then:
+
+```shell
+python3 build.py --ios --upload-ios --yes
+```
+
+Uploads deliver the binary only (TestFlight / Play track). They do not submit for App Review or promote a production rollout.

--- a/README.en.md
+++ b/README.en.md
@@ -2,8 +2,8 @@
 
 *[Auf Deutsch lesen](README.md)*
 
-Your app for the Hessian school portal! In cooperation with the state school authority for the Groß-Gerau district and the Main-Taunus district.
-**In use at numerous schools in Hesse with over 35 thousand daily users.**
+Your app for the Hessian school portal! In cooperation with the staatliches Schulamt für den Landkreis Groß-Gerau und den Main-Taunus-Kreis.
+**In use at numerous schools in Hesse with over 45 thousand daily users.**
 
 <p align="center">
     <img src="https://github.com/alessioC42/lanis-mobile/assets/84250128/19d30436-32f7-4cbe-b78e-f2fee3583c28" width="60%">

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Lanis Mobile
 
+*[Read this in English](README.en.md)*
 
 Deine App für das hessische Schulportal! In Zusammenarbeit mit dem staatlichen Schulamt für den Landkreis Groß-Gerau und den Main-Taunus-Kreis
 **Einsatz an zahlreichen Schulen in Hessen mit über 35 Tausend täglichen Nutzern.**
@@ -22,10 +23,10 @@ Deine App für das hessische Schulportal! In Zusammenarbeit mit dem staatlichen 
     </tr>
     <tr>
         <td colspan='3'>
-            <a href='https://lanis-mobile.github.io/'>website</a>
+            <a href='https://lanis-mobile.github.io/'>Website</a>
         </td>
         <td colspan='3'>
-            <a href='https://discord.gg/MGYaSetUsY'>discord</a>
+            <a href='https://discord.gg/MGYaSetUsY'>Discord</a>
         </td>
     </tr>
 </table>
@@ -53,53 +54,52 @@ Scheue dich nicht, einen Bug-Report zu erstellen, wenn du einen Fehler findest. 
 
 Bug-Reports können auch an <a href="mailto:lanis-mobile@alessioc42.dev">diese</a> E-Mail-Adresse gesendet werden, falls kein Github-Konto vorhanden ist.
 
-## Get started with development
-### 1. [Setup Flutter](https://docs.flutter.dev/get-started/quick) with your favourite IDE (Android Studio / VScode recommended)
+## Erste Schritte für die Entwicklung
+### 1. [Flutter einrichten](https://docs.flutter.dev/get-started/quick) mit deiner bevorzugten IDE (Android Studio / VScode empfohlen)
 
-### 2. Generate the code 
-*You do not need to do this, if you cloned the repository freshly, since we have this checked into source control*
+### 2. Code generieren
 ```shell
-dart run build_runner build # Database
-dart run intl_utils:generate # Localisations
+dart run build_runner build # Datenbank
+dart run intl_utils:generate # Lokalisierungen
 ```
-### 3. Development
-Note the flags here:
+### 3. Entwicklung
+Beachte hierbei folgende Flags:
 #### `--dart-define=cronetHttpNoPlay=true`
-**[Partially optional]**
-This flag is used to include the Cronet binary for networking on non-Play-Services-enabled devices (we also ship this version on the Play Store)
+**[Teilweise optional]**
+Dieses Flag wird verwendet, um die Cronet-Binärdatei für das Networking auf Geräten ohne Play Services einzubinden (diese Version stellen wir auch im Play Store bereit).
 
-If you are currently using the default Android emulator image, consider using an AOSP image instead, as these tend to perform much better than versions with Play Services enabled.
+Falls du aktuell das Standard-Android-Emulator-Image verwendest, solltest du stattdessen ein AOSP-Image nutzen, da diese in der Regel deutlich performanter sind als Versionen mit Play Services.
 
-On iOS builds this flag is not required.
+Bei iOS-Builds ist dieses Flag nicht erforderlich.
 
-#### `--dart-define=ANSI=true` 
+#### `--dart-define=ANSI=true`
 **[Optional]**
-This flag allows the application's logs to be colorized, which can help a lot if you are not already using your IDE's log-filtering tools. (Recommended to omit on macOS due to lack of support in the default Terminal)
+Dieses Flag ermöglicht farbige Logs der Anwendung, was sehr hilfreich sein kann, falls du noch nicht die Log-Filter-Tools deiner IDE nutzt. (Auf macOS wird empfohlen, dieses Flag wegzulassen, da das Standard-Terminal dies nicht unterstützt.)
 
 ```shell
 flutter run --dart-define=cronetHttpNoPlay=true --dart-define=ANSI=true
 ```
 
-### 4. Production
-For actual release mode signing is required, which can be added via placing the respective `key.properties` and `local.properties` in the `android` directory. On iOS the Development team has to be changed in Xcode. 
+### 4. Produktion
+Für den tatsächlichen Release-Modus ist eine Signierung erforderlich. Dafür müssen die entsprechenden Dateien `key.properties` und `local.properties` im `android`-Verzeichnis abgelegt werden. Bei iOS muss in Xcode das Development Team geändert werden.
 
-If you are producing a build that you intend to distribute to other people, please consider changing the app ID from `io.github.alessioc42.sph` to `io.github.alessioc42.sph.<fork|dev>.<YOUR_NAME>` or any other name that is different from the original app ID. This will prevent conflicts with the store versions that we are publishing.
+Falls du einen Build erstellst, den du an andere Personen weitergeben möchtest, ändere bitte die App-ID von `io.github.alessioc42.sph` in `io.github.alessioc42.sph.<fork|dev>.<DEIN_NAME>` oder einen anderen Namen, der sich von der Original-App-ID unterscheidet. Dies verhindert Konflikte mit den von uns veröffentlichten Store-Versionen.
 
 ```shell
 flutter build <apk|aab|ipa> --release --dart-define=cronetHttpNoPlay=true
 ```
 
-An alternative is the interactive `build.py` script, which can build Android and/or iOS in one run, copy artifacts into `artifacts/`, and optionally upload to App Store Connect / Google Play:
+Alternativ gibt es das interaktive Skript `build.py`, das Android und/oder iOS in einem Durchlauf bauen, die Artefakte nach `artifacts/` kopieren und optional zu App Store Connect / Google Play hochladen kann:
 
 ```shell
 python3 build.py
-# or non-interactive:
+# oder nicht-interaktiv:
 python3 build.py --android --ios --skip-upgrade --yes
 ```
 
-#### Store uploads (optional)
+#### Store-Uploads (optional)
 
-`build.py` loads secrets from gitignored `.env` / `.build.env` in the repo root (real environment variables win). Example:
+`build.py` lädt Zugangsdaten aus den (per `.gitignore` ausgeschlossenen) Dateien `.env` / `.build.env` im Repository-Root (echte Umgebungsvariablen haben Vorrang). Beispiel:
 
 ```env
 ASC_API_KEY_ID=XXXXXXXXXX
@@ -108,19 +108,19 @@ ASC_API_KEY_PATH=/path/to/AuthKey_XXXXXXXXXX.p8
 PLAY_SERVICE_ACCOUNT_JSON=/path/to/service-account.json
 ```
 
-Extra file: `python3 build.py --env-file /path/to/secrets.env`.
+Zusätzliche Datei: `python3 build.py --env-file /path/to/secrets.env`.
 
-For Play uploads, install the optional Python deps and use a Google Cloud service account that has been invited in Play Console (Users and permissions) with permission to manage tracks:
+Für Play-Uploads installiere die optionalen Python-Abhängigkeiten und verwende ein Google-Cloud-Service-Konto, das in der Play Console (Nutzer und Berechtigungen) mit der Berechtigung zur Verwaltung von Tracks eingeladen wurde:
 
 ```shell
 pip install -r requirements-build.txt
 python3 build.py --android --upload-android --play-track internal --yes
 ```
 
-For App Store Connect uploads (macOS + Xcode), create an App Store Connect API key, put the values in `.env` (or export them), then:
+Für App-Store-Connect-Uploads (macOS + Xcode) erstelle einen App Store Connect API-Key, trage die Werte in `.env` ein (oder exportiere sie) und führe dann aus:
 
 ```shell
 python3 build.py --ios --upload-ios --yes
 ```
 
-Uploads deliver the binary only (TestFlight / Play track). They do not submit for App Review or promote a production rollout.
+Uploads liefern lediglich die Binärdatei aus (TestFlight / Play-Track). Sie reichen den Build nicht zur App-Review ein und geben kein Produktions-Rollout frei.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 *[Read this in English](README.en.md)*
 
 Deine App für das hessische Schulportal! In Zusammenarbeit mit dem staatlichen Schulamt für den Landkreis Groß-Gerau und den Main-Taunus-Kreis
-**Einsatz an zahlreichen Schulen in Hessen mit über 40 Tausend täglichen Nutzern.**
+**Einsatz an zahlreichen Schulen in Hessen mit über 45 Tausend täglichen Nutzern.**
 
 <p align="center">
     <img src="https://github.com/alessioC42/lanis-mobile/assets/84250128/19d30436-32f7-4cbe-b78e-f2fee3583c28" width="60%">


### PR DESCRIPTION
Split the previously mixed-language README.md into two dedicated
files:
- README.md (German, default)
- README.en.md (English)

Both files cross-link to each other at the top.

Also removed the outdated note claiming generated code (build_runner /
intl_utils output) is checked into source control, it is actually
excluded via .gitignore (generated/), so contributors do need to run
the generation step after cloning.