### PR TITLE
Unify background notifications on background_fetch.

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -45,22 +45,6 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
-
-        <service
-            android:name="dev.fluttercommunity.plus.androidalarmmanager.AlarmService"
-            android:permission="android.permission.BIND_JOB_SERVICE"
-            android:exported="false" />
-        <receiver
-            android:name="dev.fluttercommunity.plus.androidalarmmanager.AlarmBroadcastReceiver"
-            android:exported="false" />
-        <receiver
-            android:name="dev.fluttercommunity.plus.androidalarmmanager.RebootBroadcastReceiver"
-            android:enabled="false"
-            android:exported="false">
-            <intent-filter>
-                <action android:name="android.intent.action.BOOT_COMPLETED" />
-            </intent-filter>
-        </receiver>
     </application>
     <uses-permission android:name="android.permission.INTERNET" tools:ignore="ManifestOrder" />
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        maven { url "${project(':background_fetch').projectDir}/libs" }
     }
     subprojects {
         afterEvaluate { project ->

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -6,50 +6,12 @@ PODS:
     - TSBackgroundFetch (~> 4.1.0)
   - device_info_plus (0.0.1):
     - Flutter
-  - DKImagePickerController/Core (4.3.9):
-    - DKImagePickerController/ImageDataManager
-    - DKImagePickerController/Resource
-  - DKImagePickerController/ImageDataManager (4.3.9)
-  - DKImagePickerController/PhotoGallery (4.3.9):
-    - DKImagePickerController/Core
-    - DKPhotoGallery
-  - DKImagePickerController/Resource (4.3.9)
-  - DKPhotoGallery (0.0.19):
-    - DKPhotoGallery/Core (= 0.0.19)
-    - DKPhotoGallery/Model (= 0.0.19)
-    - DKPhotoGallery/Preview (= 0.0.19)
-    - DKPhotoGallery/Resource (= 0.0.19)
-    - SDWebImage
-    - SwiftyGif
-  - DKPhotoGallery/Core (0.0.19):
-    - DKPhotoGallery/Model
-    - DKPhotoGallery/Preview
-    - SDWebImage
-    - SwiftyGif
-  - DKPhotoGallery/Model (0.0.19):
-    - SDWebImage
-    - SwiftyGif
-  - DKPhotoGallery/Preview (0.0.19):
-    - DKPhotoGallery/Model
-    - DKPhotoGallery/Resource
-    - SDWebImage
-    - SwiftyGif
-  - DKPhotoGallery/Resource (0.0.19):
-    - SDWebImage
-    - SwiftyGif
-  - file_picker (0.0.1):
-    - DKImagePickerController/PhotoGallery
+  - file_picker_darwin (1.0.0):
     - Flutter
+    - FlutterMacOS
   - Flutter (1.0.0)
   - flutter_background_executor (0.0.1):
     - Flutter
-  - flutter_inappwebview_ios (0.0.1):
-    - Flutter
-    - flutter_inappwebview_ios/Core (= 0.0.1)
-    - OrderedSet (~> 6.0.3)
-  - flutter_inappwebview_ios/Core (0.0.1):
-    - Flutter
-    - OrderedSet (~> 6.0.3)
   - flutter_keyboard_visibility_temp_fork (0.0.1):
     - Flutter
   - flutter_local_notifications (0.0.1):
@@ -63,18 +25,14 @@ PODS:
     - Flutter
   - open_file_ios (1.0.3):
     - Flutter
-  - OrderedSet (6.0.3)
   - package_info_plus (0.4.5):
     - Flutter
   - permission_handler_apple (9.4.8):
     - Flutter
   - quill_native_bridge_ios (0.0.1):
     - Flutter
-  - SDWebImage (5.21.7):
-    - SDWebImage/Core (= 5.21.7)
-  - SDWebImage/Core (5.21.7)
   - Sentry/HybridSDK (8.58.4)
-  - sentry_flutter (9.26.0):
+  - sentry_flutter (9.28.0):
     - Flutter
     - FlutterMacOS
     - Sentry/HybridSDK (= 8.58.4)
@@ -83,19 +41,20 @@ PODS:
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - SwiftyGif (5.4.5)
   - TSBackgroundFetch (4.1.1)
   - url_launcher_ios (0.0.1):
     - Flutter
+  - webview_flutter_wkwebview (0.0.1):
+    - Flutter
+    - FlutterMacOS
 
 DEPENDENCIES:
   - app_settings (from `.symlinks/plugins/app_settings/ios`)
   - background_fetch (from `.symlinks/plugins/background_fetch/ios`)
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
-  - file_picker (from `.symlinks/plugins/file_picker/ios`)
+  - file_picker_darwin (from `.symlinks/plugins/file_picker_darwin/darwin`)
   - Flutter (from `Flutter`)
   - flutter_background_executor (from `.symlinks/plugins/flutter_background_executor/ios`)
-  - flutter_inappwebview_ios (from `.symlinks/plugins/flutter_inappwebview_ios/ios`)
   - flutter_keyboard_visibility_temp_fork (from `.symlinks/plugins/flutter_keyboard_visibility_temp_fork/ios`)
   - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - flutter_secure_storage_darwin (from `.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
@@ -109,15 +68,11 @@ DEPENDENCIES:
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
+  - webview_flutter_wkwebview (from `.symlinks/plugins/webview_flutter_wkwebview/darwin`)
 
 SPEC REPOS:
   trunk:
-    - DKImagePickerController
-    - DKPhotoGallery
-    - OrderedSet
-    - SDWebImage
     - Sentry
-    - SwiftyGif
     - TSBackgroundFetch
 
 EXTERNAL SOURCES:
@@ -127,14 +82,12 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/background_fetch/ios"
   device_info_plus:
     :path: ".symlinks/plugins/device_info_plus/ios"
-  file_picker:
-    :path: ".symlinks/plugins/file_picker/ios"
+  file_picker_darwin:
+    :path: ".symlinks/plugins/file_picker_darwin/darwin"
   Flutter:
     :path: Flutter
   flutter_background_executor:
     :path: ".symlinks/plugins/flutter_background_executor/ios"
-  flutter_inappwebview_ios:
-    :path: ".symlinks/plugins/flutter_inappwebview_ios/ios"
   flutter_keyboard_visibility_temp_fork:
     :path: ".symlinks/plugins/flutter_keyboard_visibility_temp_fork/ios"
   flutter_local_notifications:
@@ -161,35 +114,32 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
+  webview_flutter_wkwebview:
+    :path: ".symlinks/plugins/webview_flutter_wkwebview/darwin"
 
 SPEC CHECKSUMS:
   app_settings: 0341ec6daa4f0c50f5a421bf0ad7c36084db6e90
   background_fetch: b273c4b6911fc2e309790b46b5658b7edc40b73b
   device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
-  DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
-  DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
-  file_picker: a0560bc09d61de87f12d246fc47d2119e6ef37be
-  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  file_picker_darwin: 4c2b9a50ea44cb3b071381ea0cf48591bdd80251
+  Flutter: 71a624a5bc0c04062bf19101d501e466baf2fb47
   flutter_background_executor: 8896055e67e989e9e1c02d84884b0dfaf9acce82
-  flutter_inappwebview_ios: b89ba3482b96fb25e00c967aae065701b66e9b99
   flutter_keyboard_visibility_temp_fork: 95b2d534bacf6ac62e7fcbe5c2a9e2c2a17ce06f
   flutter_local_notifications: 643a3eda1ce1c0599413ca31672536d423dee214
   flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
   image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
   is_ios_simulator: 1125d89fceb232f353d3ec3602c9a67da6e6aada
   open_file_ios: c1143c28b4c65f721cdd58d9fba2f7a1c55206cd
-  OrderedSet: e539b66b644ff081c73a262d24ad552a69be3a94
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   permission_handler_apple: 92d754bbaa7361d436db2d6c3c1c2a0fdcec462e
   quill_native_bridge_ios: f47af4b14e7757968486641656c5d23250cee521
-  SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
   Sentry: 5321d74bdd28d6f6f8beaa1ca06f1fdc746bff49
-  sentry_flutter: 01a996130a18996b59600c51e68b0e6364cde8b3
+  sentry_flutter: 771dee2d190e0952aa3873211c4a3a10f0c1ef04
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
-  SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
   TSBackgroundFetch: 18918b6449a1e3f01eb0f5b44d6d79ce6160a5a5
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
+  webview_flutter_wkwebview: 8ebf4fded22593026f7dbff1fbff31ea98573c8d
 
 PODFILE CHECKSUM: 730d2d1ad5a7d04af09871cb0734b17ea30169ba
 

--- a/lib/background_service.dart
+++ b/lib/background_service.dart
@@ -1,10 +1,8 @@
 import 'dart:convert';
-import 'dart:io';
 
-import 'package:background_fetch/background_fetch.dart' as bgf;
+import 'package:background_fetch/background_fetch.dart';
 import 'package:crypto/crypto.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_background_executor/flutter_background_executor.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:liblanis/liblanis.dart';
@@ -16,10 +14,50 @@ import 'package:lanis/l10n/account_type_ui.dart';
 import 'package:lanis/utils/logger.dart';
 import 'package:lanis/utils/privacy_policy.dart';
 
+const _oneShotTaskId = 'com.transistorsoft.notftask';
+
+/// Android headless entry (app swiped away). iOS ignores this registration.
+@pragma('vm:entry-point')
+void backgroundFetchHeadlessTask(HeadlessEvent event) async {
+  await _runFetchTask(event.taskId, timeout: event.timeout);
+}
+
+Future<void> _onBackgroundFetch(String taskId) async {
+  await _runFetchTask(taskId, timeout: false);
+}
+
+Future<void> _onBackgroundFetchTimeout(String taskId) async {
+  await _runFetchTask(taskId, timeout: true);
+}
+
+Future<void> _runFetchTask(String taskId, {required bool timeout}) async {
+  debugPrint('[Lanis BG] fetch taskId=$taskId timeout=$timeout');
+  if (timeout) {
+    await BackgroundFetch.finish(taskId);
+    return;
+  }
+  try {
+    await callbackDispatcher();
+  } finally {
+    await BackgroundFetch.finish(taskId);
+    debugPrint('[Lanis BG] fetch finished taskId=$taskId');
+  }
+}
+
+Future<void> _stopBackgroundFetch() async {
+  try {
+    await BackgroundFetch.stop();
+  } catch (e, s) {
+    backgroundLogger.e(e, stackTrace: s);
+  }
+}
+
 Future<void> setupBackgroundService() async {
+  await BackgroundFetch.registerHeadlessTask(backgroundFetchHeadlessTask);
+
   if ((await Permission.notification.isDenied)) {
     logger.d('User disallowed notifications');
-    await FlutterBackgroundExecutor().cancelAllTasks();
+    await _stopBackgroundFetch();
     return;
   }
 
@@ -39,7 +77,7 @@ Future<void> setupBackgroundService() async {
       }
     }
     if (accounts.isNotEmpty && disabledCount == accounts.length) {
-      await FlutterBackgroundExecutor().cancelAllTasks();
+      await _stopBackgroundFetch();
       return;
     }
 
@@ -50,49 +88,32 @@ Future<void> setupBackgroundService() async {
       'Setting up background task with interval of $targetIntervalMinutes minutes',
     );
 
-    if (Platform.isAndroid) {
-      await FlutterBackgroundExecutor().createRefreshTask(
-        callback: callbackDispatcher,
-        settings: RefreshTaskSettings(
-          androidDetails: AndroidRefreshTaskDetails(
-            requiresBatteryNotLow: true,
-            requiresCharging: false,
-            requiresDeviceIdle: false,
-            requiresStorageNotLow: false,
-            initialDelay: Duration.zero,
-            repeatInterval: Duration(minutes: targetIntervalMinutes),
-          ),
+    try {
+      await BackgroundFetch.configure(
+        BackgroundFetchConfig(
+          minimumFetchInterval: targetIntervalMinutes,
+          stopOnTerminate: false,
+          startOnBoot: true,
+          enableHeadless: true,
+          requiresBatteryNotLow: true,
+          requiresCharging: false,
+          requiresDeviceIdle: false,
+          requiresStorageNotLow: false,
+        ),
+        _onBackgroundFetch,
+        _onBackgroundFetchTimeout,
+      );
+
+      await BackgroundFetch.scheduleTask(
+        TaskConfig(
+          taskId: _oneShotTaskId,
+          delay: 10000,
+          enableHeadless: true,
+          stopOnTerminate: false,
         ),
       );
-      await FlutterBackgroundExecutor().runImmediatelyBackgroundTask(
-        callback: callbackDispatcher,
-      );
-    }
-
-    if (Platform.isIOS) {
-      try {
-        await bgf.BackgroundFetch.configure(
-          bgf.BackgroundFetchConfig(
-            minimumFetchInterval: targetIntervalMinutes,
-          ),
-          (String taskId) async {
-            try {
-              await callbackDispatcher();
-            } finally {
-              bgf.BackgroundFetch.finish(taskId);
-            }
-          },
-          (String taskId) async {
-            bgf.BackgroundFetch.finish(taskId);
-          },
-        );
-
-        await bgf.BackgroundFetch.scheduleTask(
-          bgf.TaskConfig(taskId: 'com.transistorsoft.notftask', delay: 10000),
-        );
-      } catch (e, s) {
-        backgroundLogger.e(e, stackTrace: s);
-      }
+    } catch (e, s) {
+      backgroundLogger.e(e, stackTrace: s);
     }
   } finally {
     container.dispose();
@@ -119,7 +140,9 @@ Future<void> initializeNotifications() async {
 @pragma('vm:entry-point')
 Future<void> callbackDispatcher() async {
   try {
+    WidgetsFlutterBinding.ensureInitialized();
     backgroundLogger.i('Background fetch triggered');
+    debugPrint('[Lanis BG] callbackDispatcher started');
     await initializeNotifications();
 
     await removeLegacyV3StorageArtifacts();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,7 +37,6 @@ dependencies:
   flutter_launcher_icons: ^0.14.0
   flutter_local_notifications: ^21.0.0
   background_fetch: ^1.6.2
-  flutter_background_executor: ^1.0.0
   permission_handler: ^12.0.1
   package_info_plus: ^10.2.1
   encrypt: ^5.0.3
@@ -56,7 +55,7 @@ dependencies:
   table_calendar: ^3.0.9
   flutter_localizations:
     sdk: flutter
-  app_settings: ^9.0.0
+  app_settings: ^7.0.0
   device_info_plus: ^13.2.0
   flutter_quill: ^11.5.1
   webview_flutter: ^4.14.1


### PR DESCRIPTION
Drop flutter_background_executor so Android uses the same JobScheduler/BGTask path as iOS, including headless fetch after process death.