### PR TITLE
fix: hour-label column no longer overflows on longer labels

### DIFF
--- a/lib/applets/timetable/student/student_timetable_better_view.dart
+++ b/lib/applets/timetable/student/student_timetable_better_view.dart
@@ -369,22 +369,26 @@ class TimeTableView extends StatelessWidget {
                         height: row.type == TimeTableRowType.lesson
                             ? itemHeight
                             : pauseHeight,
-                        child: Column(
-                          children: [
-                            Text(row.label, style: TextStyle(fontSize: 12)),
-                            ...(row.type == TimeTableRowType.lesson
-                                ? [
-                                    Text(
-                                      row.startTime.toFlutter().format(context),
-                                      style: TextStyle(fontSize: 10),
-                                    ),
-                                    Text(
-                                      row.endTime.toFlutter().format(context),
-                                      style: TextStyle(fontSize: 10),
-                                    ),
-                                  ]
-                                : []),
-                          ],
+                        child: FittedBox(
+                          fit: BoxFit.scaleDown,
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Text(row.label, style: TextStyle(fontSize: 12)),
+                              ...(row.type == TimeTableRowType.lesson
+                                  ? [
+                                      Text(
+                                        row.startTime.toFlutter().format(context),
+                                        style: TextStyle(fontSize: 10),
+                                      ),
+                                      Text(
+                                        row.endTime.toFlutter().format(context),
+                                        style: TextStyle(fontSize: 10),
+                                      ),
+                                    ]
+                                  : []),
+                            ],
+                          ),
                         ),
                       ),
                   ],


### PR DESCRIPTION
Found in testing: the left-hand hour column (period label + start/end time, 3 stacked Text widgets) had a fixed height and could overflow when the label needed more than one line. Wrapped the content in FittedBox(fit: BoxFit.scaleDown) so it always scales down to fit instead of overflowing, regardless of label length.