### PR TITLE
feature: curated subject colors with quick-pick in the timetable color dialog

### DIFF
--- a/assets/subject_colors.json
+++ b/assets/subject_colors.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "deutsch",
+    "aliases": ["de", "deu", "deutsch", "d"],
+    "primary": "#C62828",
+    "alternatives": ["#8B0000"]
+  },
+  {
+    "id": "mathematik",
+    "aliases": ["ma", "mathe", "mathematik", "m"],
+    "primary": "#1565C0",
+    "alternatives": ["#0D47A1"]
+  },
+  {
+    "id": "englisch",
+    "aliases": ["en", "eng", "englisch", "e"],
+    "primary": "#EC407A",
+    "alternatives": ["#D81B60"]
+  },
+  {
+    "id": "franzoesisch",
+    "aliases": ["fr", "franz", "franzoesisch", "f"],
+    "primary": "#4FC3F7",
+    "alternatives": ["#26C6DA"]
+  },
+  {
+    "id": "latein",
+    "aliases": ["la", "latein", "l"],
+    "primary": "#8D6E63",
+    "alternatives": []
+  },
+  {
+    "id": "spanisch",
+    "aliases": ["sp", "span", "spanisch", "s"],
+    "primary": "#E64A19",
+    "alternatives": []
+  },
+  {
+    "id": "biologie",
+    "aliases": ["bio", "biologie"],
+    "primary": "#2E7D32",
+    "alternatives": []
+  },
+  {
+    "id": "chemie",
+    "aliases": ["ch", "chem", "chemie"],
+    "primary": "#00897B",
+    "alternatives": ["#FBC02D"]
+  },
+  {
+    "id": "physik",
+    "aliases": ["ph", "phys", "physik", "phy"],
+    "primary": "#607D8B",
+    "alternatives": ["#FB8C00"]
+  },
+  {
+    "id": "informatik",
+    "aliases": ["inf", "info", "informatik"],
+    "primary": "#00838F",
+    "alternatives": ["#90A4AE"]
+  },
+  {
+    "id": "geschichte",
+    "aliases": ["ge", "gesch", "geschichte", "g"],
+    "primary": "#A1887F",
+    "alternatives": ["#C9A876"]
+  },
+  {
+    "id": "erdkunde",
+    "aliases": ["ek", "erdkunde", "geo", "geographie"],
+    "primary": "#EF6C00",
+    "alternatives": ["#558B2F"]
+  },
+  {
+    "id": "powi",
+    "aliases": ["powi", "pw", "politik", "wirtschaft"],
+    "primary": "#F9A825",
+    "alternatives": ["#8D6E63"]
+  },
+  {
+    "id": "religion",
+    "aliases": ["eth", "ethik", "ethi", "re", "rel", "religion", "ev", "rev", "rk", "ka", "rka"],
+    "primary": "#7E57C2",
+    "alternatives": ["#F5F5F5"]
+  },
+  {
+    "id": "kunst",
+    "aliases": ["ku", "kunst"],
+    "primary": "#C2185B",
+    "alternatives": ["#F4511E"]
+  },
+  {
+    "id": "musik",
+    "aliases": ["mu", "musik"],
+    "primary": "#FDD835",
+    "alternatives": ["#F06292"]
+  },
+  {
+    "id": "sport",
+    "aliases": ["sport", "spo"],
+    "primary": "#FF7043",
+    "alternatives": ["#9CCC65"]
+  },
+  {
+    "id": "darstellendesspiel",
+    "aliases": ["ds", "darstellendesspiel", "dsp"],
+    "primary": "#8E24AA",
+    "alternatives": ["#880E4F"]
+  },
+  {
+    "id": "philosophie",
+    "aliases": ["phil", "philosophie"],
+    "primary": "#757575",
+    "alternatives": ["#78909C"]
+  },
+  {
+    "id": "sozialkunde",
+    "aliases": ["sk", "sowi"],
+    "primary": "#00695C",
+    "alternatives": []
+  }
+]

--- a/lib/applets/timetable/student/student_timetable_item.dart
+++ b/lib/applets/timetable/student/student_timetable_item.dart
@@ -9,6 +9,7 @@ import 'package:lanis/applets/timetable/student/student_timetable_better_view.da
 import 'package:lanis/applets/timetable/student/timetable_helper.dart';
 import 'package:lanis/generated/l10n.dart';
 import 'package:lanis/utils/root_nav.dart';
+import 'package:lanis/utils/subject_colors.dart';
 
 class ItemBlock extends StatelessWidget {
   final TimetableSubject? subject;
@@ -46,19 +47,72 @@ class ItemBlock extends StatelessWidget {
     TimetableSubject lesson,
   ) {
     Color selectedColor = TimeTableHelper.getColorForLesson(settings, lesson);
+    final curated = SubjectColors.lookup(lesson.name!);
+    final quickPickColors = curated == null
+        ? const <Color>[]
+        : [curated.primary, ...curated.alternatives];
+
     showDialog(
       context: context,
       builder: (BuildContext context) {
-        return AlertDialog(
-          content: SingleChildScrollView(
-            child: ColorPicker(
-              pickerColor: selectedColor,
-              onColorChanged: (c) => {selectedColor = c},
-              enableAlpha: false,
-              labelTypes: [],
-            ),
-          ),
-          actions: <Widget>[
+        return StatefulBuilder(
+          builder: (context, setDialogState) {
+            return AlertDialog(
+              content: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (quickPickColors.isNotEmpty) ...[
+                      Text(
+                        AppLocalizations.of(context).timetableColorSuggestions,
+                        style: Theme.of(context).textTheme.labelLarge,
+                      ),
+                      const SizedBox(height: 8),
+                      Wrap(
+                        spacing: 12,
+                        runSpacing: 12,
+                        children: quickPickColors.map((swatchColor) {
+                          final bool isSelected =
+                              selectedColor.toARGB32() ==
+                              swatchColor.toARGB32();
+                          return GestureDetector(
+                            onTap: () {
+                              setDialogState(() {
+                                selectedColor = swatchColor;
+                              });
+                            },
+                            child: Container(
+                              width: 36,
+                              height: 36,
+                              decoration: BoxDecoration(
+                                color: swatchColor,
+                                shape: BoxShape.circle,
+                                border: Border.all(
+                                  color: isSelected
+                                      ? Theme.of(context).colorScheme.primary
+                                      : Colors.transparent,
+                                  width: 3,
+                                ),
+                              ),
+                            ),
+                          );
+                        }).toList(),
+                      ),
+                      const SizedBox(height: 16),
+                    ],
+                    ColorPicker(
+                      pickerColor: selectedColor,
+                      onColorChanged: (c) => setDialogState(() {
+                        selectedColor = c;
+                      }),
+                      enableAlpha: false,
+                      labelTypes: [],
+                    ),
+                  ],
+                ),
+              ),
+              actions: <Widget>[
             ElevatedButton(
               child: Text(AppLocalizations.of(context).clear),
               onPressed: () {
@@ -91,7 +145,9 @@ class ItemBlock extends StatelessWidget {
                 updateSettings('lesson-colors', colors);
               },
             ),
-          ],
+              ],
+            );
+          },
         );
       },
     );

--- a/lib/applets/timetable/student/timetable_helper.dart
+++ b/lib/applets/timetable/student/timetable_helper.dart
@@ -1,17 +1,26 @@
 import 'package:flutter/material.dart';
 import 'package:liblanis/liblanis.dart';
 import 'package:lanis/utils/random_color.dart';
+import 'package:lanis/utils/subject_colors.dart';
 
 class TimeTableHelper {
   static Color getColorForLesson(dynamic settings, lesson) {
+    // 1. Did the user pick a custom color for this lesson themselves?
     final colors = settings is Map ? settings['lesson-colors'] : null;
-    if (colors is! Map) {
-      return RandomColor.bySeed(lesson.name!).primary;
+    if (colors is Map) {
+      final stored = colors[lesson.id.split('-')[0]];
+      if (stored is String && stored.isNotEmpty) {
+        return Color(int.parse(stored, radix: 16));
+      }
     }
-    final stored = colors[lesson.id.split('-')[0]];
-    if (stored is String && stored.isNotEmpty) {
-      return Color(int.parse(stored, radix: 16));
+
+    // 2. Does the (normalized) subject name match our curated color table?
+    final curated = SubjectColors.lookup(lesson.name!);
+    if (curated != null) {
+      return curated.primary;
     }
+
+    // 3. Last resort: deterministic hash-based color.
     return RandomColor.bySeed(lesson.name!).primary;
   }
 

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -277,6 +277,7 @@
   "timetableSwitchToClass": "Wechsel zum Klassenstundenplan",
   "timetableAllWeeks": "Gesamtplan",
   "timetableWeek": "{week}-Woche",
+  "timetableColorSuggestions": "Vorschläge",
   "dateWithHours": "{date}, {hours} Stunde",
   "contributors": "Mitwirkende",
   "becomeContributor": "Werde Mitwirkender!",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -321,6 +321,7 @@
   "timetableSwitchToClass": "Switch to Class timetable",
   "timetableAllWeeks": "All Weeks",
   "timetableWeek": "{week}-Week",
+  "timetableColorSuggestions": "Suggestions",
   "contributors": "Contributors",
   "becomeContributor": "Become a contributor",
   "done": "Done",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,6 +20,7 @@ import 'package:lanis/utils/glitchtip.dart';
 import 'package:lanis/utils/logger.dart';
 import 'package:lanis/utils/mono_text_viewer.dart';
 import 'package:lanis/utils/phoenix.dart';
+import 'package:lanis/utils/subject_colors.dart';
 import 'package:lanis/utils/theme_settings.dart';
 import 'package:lanis/view/startup_error_view.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
@@ -54,6 +55,7 @@ Future<void> _startApp() async {
     }
 
     await initializeDateFormatting();
+    await SubjectColors.ensureLoaded();
 
     runApp(
       ProviderScope(

--- a/lib/utils/subject_colors.dart
+++ b/lib/utils/subject_colors.dart
@@ -1,0 +1,100 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
+
+/// A curated color for a subject, together with a couple of alternatives
+/// that can be offered as a quick-pick next to the free-form color picker.
+class SubjectColorEntry {
+  final Color primary;
+  final List<Color> alternatives;
+
+  const SubjectColorEntry({required this.primary, required this.alternatives});
+}
+
+/// Loads `assets/subject_colors.json` and allows looking up a curated color
+/// for a subject by matching its *normalized* name against a list of known
+/// aliases (full names and common abbreviations).
+///
+/// Normalization strips everything that is not a letter and lowercases the
+/// rest, so "bio", "BIOLOGIE" and "Bio!" all resolve to the same lookup key.
+/// This only works for an exact match after stripping punctuation/case —
+/// it does *not* extract a "core" subject token from a longer combined
+/// string. Names like "Bio (GK)" or "Biologie - S2" will normalize to
+/// "biogk"/"biologies" respectively, which won't match the "bio"/"biologie"
+/// aliases, and [lookup] falls through to the caller's own fallback (see
+/// `TimeTableHelper.getColorForLesson`, which falls back to a hash-based
+/// color). In practice `TimetableSubject.name` is the bare, portal-parsed
+/// subject abbreviation (course/group qualifiers are parsed into a
+/// separate `badge` field upstream), so this is expected to match the
+/// common case; schools whose Stundenplan display settings embed course
+/// info directly into the subject name may see more fallback colors.
+class SubjectColors {
+  SubjectColors._();
+
+  static Map<String, SubjectColorEntry>? _aliasLookup;
+
+  static final RegExp _letterPattern = RegExp(r'[a-zA-ZäöüÄÖÜß]');
+
+  /// Removes everything that is not a letter and lowercases the input.
+  static String normalize(String input) {
+    final buffer = StringBuffer();
+    for (final rune in input.runes) {
+      final char = String.fromCharCode(rune);
+      if (_letterPattern.hasMatch(char)) {
+        buffer.write(char.toLowerCase());
+      }
+    }
+    return buffer.toString();
+  }
+
+  /// Loads and parses the JSON asset. Safe to call multiple times; only
+  /// loads once. Should be awaited once during app startup (see main.dart)
+  /// so that [lookup] can be used synchronously afterwards.
+  static Future<void> ensureLoaded() async {
+    if (_aliasLookup != null) return;
+
+    final Map<String, SubjectColorEntry> lookupTable = {};
+
+    try {
+      final raw = await rootBundle.loadString('assets/subject_colors.json');
+      final List<dynamic> data = json.decode(raw) as List<dynamic>;
+
+      for (final rawEntry in data) {
+        final entry = rawEntry as Map<String, dynamic>;
+        final primary = _parseHex(entry['primary'] as String);
+        final alternatives = ((entry['alternatives'] as List<dynamic>?) ?? [])
+            .map((hex) => _parseHex(hex as String))
+            .toList();
+        final colorEntry = SubjectColorEntry(
+          primary: primary,
+          alternatives: alternatives,
+        );
+
+        final aliases = (entry['aliases'] as List<dynamic>? ?? []);
+        for (final alias in aliases) {
+          lookupTable[normalize(alias as String)] = colorEntry;
+        }
+      }
+    } catch (_) {
+      // If the asset can't be loaded/parsed for some reason, we simply end
+      // up with an empty table and callers fall back to the hash-based
+      // random color, so the app keeps working either way.
+    }
+
+    _aliasLookup = lookupTable;
+  }
+
+  static Color _parseHex(String hex) {
+    final cleaned = hex.replaceAll('#', '');
+    return Color(int.parse('FF$cleaned', radix: 16));
+  }
+
+  /// Looks up a curated color entry for [subjectName]. Returns null if the
+  /// table hasn't been loaded yet, or no alias matches the normalized name.
+  static SubjectColorEntry? lookup(String subjectName) {
+    final table = _aliasLookup;
+    if (table == null || table.isEmpty) return null;
+    return table[normalize(subjectName)];
+  }
+}


### PR DESCRIPTION
getColorForLesson() now tries, in order:

1. the user's own saved per-lesson color
2. a curated color from assets/subject_colors.json, matched by normalized subject name
3. falls back to the existing hash-based random color

The color picker dialog now shows a row of quick-pick swatches (primary + alternatives) for the matched subject, alongside the existing free-form picker below.

lib/utils/subject_colors.dart is partially AI-generated but was manually tested